### PR TITLE
Coerce document URL anchor when playlist is not fully represented

### DIFF
--- a/app/helpers/mdl_blacklight_helper.rb
+++ b/app/helpers/mdl_blacklight_helper.rb
@@ -52,8 +52,13 @@ module MdlBlacklightHelper
       label = index_presenter(doc).label field
     end
 
+    anchor = doc['borealis_fragment_ssi']
+    if anchor == '/kaltura_video' && doc['kaltura_video_playlist_ssi']
+      anchor = '/kaltura_video_playlist'
+    end
+
     link_to raw(label),
-            url_for(controller: 'catalog', action: 'show', id: doc.id, anchor: doc['borealis_fragment_ssi']),
+            url_for(controller: 'catalog', action: 'show', id: doc.id, anchor: anchor),
             document_link_params(doc, opts).merge(data: { turbolinks: false })
   end
 end


### PR DESCRIPTION
Some documents seem to have a `borealis_anchor_ssi` value of
"/kaltura_video" when they should actually be "/kaltura_video_playlist".
This change attempts to discover and reconcile this condition so that
the URL on the search results page will load a player that will render
the video.

This is admittedly a hacky solve. There may be better ways of handling
this. @swandog30 - how is this data entered? If the `borealis_anchor_ssi`
values could be fixed/updated, things should work without merging
this change.

Resolves #50