### PR TITLE
Address failure to load content when using the back button

### DIFF
--- a/app/assets/javascripts/home.js.erb
+++ b/app/assets/javascripts/home.js.erb
@@ -15,15 +15,44 @@ $( document ).on('turbolinks:load', function() {
   $('.home-page .blacklight-topic_ssim h3 a').text('Minnesota Reflections Topic')
   $('.home-page .blacklight-physical_format_ssi h3 a').text('Browse By Format')
 
-$('.home-page .more_facets_link').each(function() {
-  var $this = $(this);
-  var _href = $this.attr("href");
-  $this.attr("href", _href + '?facet.sort=index');
-});
+  $('.home-page .more_facets_link').each(function() {
+    var $this = $(this);
+    var _href = $this.attr("href");
+    $this.attr("href", _href + '?facet.sort=index');
+  });
 
   $('.home-page .more_facets_link').removeClass('more_facets_link');
 
   $(document).ready(function() {
     $('.search_q').focus();
   });
+
+  reinitModal();
 });
+
+function isModalOpen () {
+  return !!$('body.modal-open').length;
+}
+
+function reinitModal () {
+  if (isModalOpen()) {
+    // If we have an open modal on turbolinks:load, we need
+    // to reinitialize it and setup some custom behavior so
+    // that it can be properly dismissed. This is typically
+    // an issue when navigating +back+ from a facet filter
+    // option that was displayed in a modal. Something about
+    // Turbolinks caching seems to be disrupting the modal
+    // event handling when loading the page from cache. I'm
+    // Not sure it's worth trying to dive into the old
+    // Bootstrap/jQuery code to figure out why it's not
+    // playing nicely with Turbolinks, but this gets the job
+    // done.
+    var $modal = $('#ajax-modal');
+    $modal.modal();
+    $modal.on('hidden.bs.modal', function () {
+      $modalBackdrop = $('.modal-backdrop');
+      $modalBackdrop.removeClass('in');
+      $modalBackdrop.remove();
+    });
+  }
+}

--- a/app/javascript/packs/viewer.jsx
+++ b/app/javascript/packs/viewer.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import Borealis from 'react-borealis';
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('turbolinks:load', () => {
     const node = document.getElementById('viewer_data')
     const viewerNode = document.getElementById('react-borealis-viewer')
     const config = JSON.parse(node.getAttribute('viewerConfig'))


### PR DESCRIPTION
The two issues outlined in issue #47 are addressed by this
pull request.

First, attach the Borealis viewer initialization to  the `turbolinks:load`
event.

Until now, we've been initializing the Borealis viewer on the
'DOMContentLoaded' event. This works really well for initial page loads,
but when we start considering browser navigation, it begins to break
down. This is because the content is loaded from the Turbolinks cache,
and no 'DOMContentLoaded' event is emitted in this scenario. If we
attach the listener to 'turbolinks:load' instead, we can successfully
initialize the player both when initially loading a document into it, as
well as navigating back to a previously loaded document.

Second, fix modal dismissal failure on browser navigation

If we have an open modal on `turbolinks:load`, we need
to reinitialize it and setup some custom behavior so
that it can be properly dismissed. This is typically
an issue when navigating +back+ from a facet filter
option that was displayed in a modal. Something about
Turbolinks caching seems to be disrupting the modal
event handling when loading the page from cache. I'm
Not sure it's worth trying to dive into the old
Bootstrap/jQuery code to figure out why it's not
playing nicely with Turbolinks, but this gets the job
done.