### PR TITLE
Remove second invocation of deploy:restart_sidekiq

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -45,10 +45,8 @@ set :passenger_restart_with_touch, true
 
 # Restart all sidekiq instances so they can pick up the new code
 namespace :deploy do
-  after :finishing, :notify do
-    invoke "deploy:restart_sidekiq"
-  end
-
+  ###
+  # Called by capistrano-sidekiq
   task :restart_sidekiq do
     on roles(:all) do |host|
       (0..2).map do |pid|


### PR DESCRIPTION
Since capistrano-sidekiq's deployment tasks already include
`deploy:restart_sidekiq`, we should remove invocation from our own
scripts. Our version of Capistrano prevents duplicate task invocations,
but that behavior is deprecated and may disappear one day.