### PR TITLE
Exclude transcript from advanced search

### DIFF
--- a/app/controllers/advanced_controller.rb
+++ b/app/controllers/advanced_controller.rb
@@ -67,6 +67,10 @@ class AdvancedController < BlacklightAdvancedSearch::AdvancedController
       }
     end
     config.add_search_field('transcript') do |field|
+      ###
+      # Temporarily excluded from advanced search. Remove
+      # next line to re-enable the transcript search input
+      field.include_in_advanced_search = false
       field.solr_parameters = { :'spellcheck.dictionary' => 'default' }
       field.solr_local_parameters = {
         qf: '$transcription_qf',


### PR DESCRIPTION
We're going to deploy the advanced search feature without the transcript
search field for now, because indexing the transcript data will take a
bit of time. We're also waiting on a decision by the librarians on
whether that particular search field should be included in the form at
all.