### PR TITLE
Add a Sidekiq config file to help with consistency and ergonomics

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,11 @@
+---
+:verbose: false
+:concurrency: 5 # Sidekiq default
+:timeout: 25
+
+# Sidekiq will run this file through ERB when reading it so you can
+# even put in dynamic logic, like a host-specific queue.
+# http://www.mikeperham.com/2013/11/13/advanced-sidekiq-host-specific-queues/
+:queues:
+  - [critical, 2]
+  - default


### PR DESCRIPTION
Sidekiq will read this file when it starts up and take its configuration options from here. This means we don't need to pass config options at the command line, but if we choose to do so, those will take precedence over the values in the file. 