### PR TITLE
Fixes facet titles from disappearing on :focus

### DIFF
--- a/app/assets/stylesheets/mdl.scss
+++ b/app/assets/stylesheets/mdl.scss
@@ -725,10 +725,12 @@ form.range_limit .btn-default {
 .panel-title > a {
 	text-decoration: none !important;
 	text-transform: none !important;
-}
-
-.panel-title > a:hover {
-	color: $black !important;
+	&:hover {
+		color: $black !important;
+	}
+	&:focus {
+		color: $white !important;
+	}
 }
 
 .constraints-container {


### PR DESCRIPTION
This CSS update will fix the disappearing facet titles in the left column of search results.