### PR TITLE
MDL identifier search support

### DIFF
--- a/app/helpers/mdl_blacklight_helper.rb
+++ b/app/helpers/mdl_blacklight_helper.rb
@@ -52,13 +52,22 @@ module MdlBlacklightHelper
       label = index_presenter(doc).label field
     end
 
+    link_to raw(label),
+            url_for(controller: 'catalog', action: 'show', id: doc.id, anchor: build_anchor(doc)),
+            document_link_params(doc, opts).merge(data: { turbolinks: false })
+  end
+
+  private
+
+  def build_anchor(doc)
     anchor = doc['borealis_fragment_ssi']
     if anchor == '/kaltura_video' && doc['kaltura_video_playlist_ssi']
       anchor = '/kaltura_video_playlist'
     end
 
-    link_to raw(label),
-            url_for(controller: 'catalog', action: 'show', id: doc.id, anchor: anchor),
-            document_link_params(doc, opts).merge(data: { turbolinks: false })
+    if sought_child_index = Array(doc['identifier_ssim']).index(params[:q])
+      anchor = "/image/#{sought_child_index}" if anchor.match(/^\/image\/\d+/)
+    end
+    anchor
   end
 end

--- a/lib/mdl/borealis_asset.rb
+++ b/lib/mdl/borealis_asset.rb
@@ -22,6 +22,7 @@ module MDL
         collection: collection,
         transcripts: transcripts,
         transcript: "#{title} \n #{transcripts.join("\n")}",
+        subtitle: subtitle,
         title: title,
         assets: assets,
         thumbnail: thumbnail
@@ -41,6 +42,10 @@ module MDL
     end
 
     private
+
+    def subtitle
+      Array(document['identifier_ssim'])[id.to_i]
+    end
 
     def sanitize_field(field)
       (field == {} || field == false || field == '') ? nil : field

--- a/lib/mdl/transformer.rb
+++ b/lib/mdl/transformer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative './multi_date_formatter'
+
 module MDL
   # CDMBL field mappings
   class Transformer

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "prop-types": "^15.6.0",
     "rails-erb-loader": "^5.2.1",
     "react": "15.4.1",
-    "react-borealis": "git+https://github.com/UMNLibraries/react-borealis.git#cd3aa11a017c",
+    "react-borealis": "git+https://github.com/Minitex/react-borealis.git#439996cb",
     "react-citation": "git+https://github.com/UMNLibraries/react-citation.git#52091d617b5d",
     "react-dom": "15.4.1",
     "react-spinkit": "^3.0.0",

--- a/spec/lib/mdl/compound_aggregating_transformer_spec.rb
+++ b/spec/lib/mdl/compound_aggregating_transformer_spec.rb
@@ -8,6 +8,7 @@ module MDL
         {dest_path: 'id', origin_path: 'id', formatters: [CDMBL::StripFormatter, CDMBL::IDFormatter]},
         {dest_path: 'compound_objects_ts', origin_path: 'page', formatters: [CDMBL::ToJsonFormatter]},
         {dest_path: 'transcription_tesi', origin_path: 'transc', formatters: [CDMBL::StripFormatter]},
+        {dest_path: 'identifier_ssi', origin_path: 'resour', formatters: [CDMBL::StripFormatter]},
         {dest_path: 'record_type', origin_path: 'record_type', formatters: []},
         {dest_path: 'parent_id', origin_path: 'parent_id', formatters: []},
         {dest_path: 'child_index', origin_path: 'child_index', formatters: []}
@@ -64,6 +65,30 @@ module MDL
             {"id"=>"blah:3248", "transcription_tesi"=>"OHAI CHEEZEBURGER 1", "record_type"=>"secondary", "parent_id"=>"foo/5123", "child_index"=>1}
           ])
         end
+      end
+    end
+
+    describe 'aggregating MDL Identifiers of compound documents' do
+      it "aggregates the MDL Identifiers of the child pages onto the parent record" do
+        records = [{
+          'id' => 'foo/5123',
+          'page' => [
+            {'id' => 'blah/3245', 'resour' => 'fakeID'},
+            {'id' => 'blah/3246', 'resour' => 'realID'},
+          ]
+        }]
+        transformation = CompoundAggregatingTransformer.new(
+          cdm_records: records,
+          field_mappings: field_mappings
+        ).records
+        expect(transformation).to eq([
+          {
+            "id"=>"foo:5123",
+            "identifier_ssim"=>["fakeID", "realID"],
+            "compound_objects_ts"=>"[{\"id\":\"blah/3245\",\"resour\":\"fakeID\"},{\"id\":\"blah/3246\",\"resour\":\"realID\"}]",
+            "record_type"=>"primary"
+          }
+        ])
       end
     end
   end

--- a/yarn.lock
+++ b/yarn.lock
@@ -6564,9 +6564,9 @@ rc@^1.2.7:
   dependencies:
     immutable "^3.8.1"
 
-"react-borealis@git+https://github.com/UMNLibraries/react-borealis.git#cd3aa11a017c":
-  version "0.1.0"
-  resolved "git+https://github.com/UMNLibraries/react-borealis.git#cd3aa11a017ce72af7a56d5e2a96745ca6d0fac6"
+"react-borealis@git+https://github.com/Minitex/react-borealis.git#439996cb":
+  version "0.2.0"
+  resolved "git+https://github.com/Minitex/react-borealis.git#439996cbd9c1ce2a38b258d203fda9f0baebb045"
   dependencies:
     babel-polyfill "^6.23.0"
     borealis-pdf "git+https://github.com/UMNLibraries/borealis-pdf.git#20ee0fcee70a3343d1d7c0"
@@ -6577,7 +6577,7 @@ rc@^1.2.7:
     prop-types "^15.5.10"
     react "^15.4.1"
     react-dom "15.4.1"
-    react-openseadragon "git+https://github.com/UMNLibraries/react-openseadragon.git#ebcba59c6"
+    react-openseadragon "git+https://github.com/Minitex/react-openseadragon.git#882b3fcb2"
     react-router "4.1.1"
     react-router-dom "^4.1.1"
 
@@ -6625,9 +6625,9 @@ react-lazy-load@^3.0.12:
     lodash.throttle "^4.0.0"
     prop-types "^15.5.8"
 
-"react-openseadragon@git+https://github.com/UMNLibraries/react-openseadragon.git#ebcba59c6":
-  version "0.2.0"
-  resolved "git+https://github.com/UMNLibraries/react-openseadragon.git#ebcba59c6cd74cc3220c31a63fd4c94488406aca"
+"react-openseadragon@git+https://github.com/Minitex/react-openseadragon.git#882b3fcb2":
+  version "0.3.0"
+  resolved "git+https://github.com/Minitex/react-openseadragon.git#882b3fcb223b4ab231ede0d06a6b67102649eaae"
   dependencies:
     history "^4.6.1"
     openseadragon "^2.3.0"


### PR DESCRIPTION
This change, along with [companion PR](https://github.com/Minitex/mdl-solr-core/pull/4) to mdl-solr-core, implements the ability to find a compound document parent when searching for the MDL identifier of one of its child documents. When clicking links to that document from the search results page, you'll be taken to the details page with the child document you searched for displayed in the viewer.

Also requires [this change to react-borealis](https://github.com/Minitex/react-borealis/pull/12) so that we can display the MDL identifier in the thumbnails within the viewer.

Addresses #48 