### PR TITLE
Selective harvesting

### DIFF
--- a/app/services/mdl/etl.rb
+++ b/app/services/mdl/etl.rb
@@ -25,9 +25,10 @@ module MDL
         cdm_endpoint: 'https://server16022.contentdm.oclc.org/dmwebservices/index.php',
         max_compounds: 1,
         batch_size: 5,
-        solr_config: solr_config,
-        from: 8.days.ago.to_date.iso8601
-      }
+        solr_config: solr_config
+      }.tap do |hsh|
+        hsh[:from] = 8.days.ago.to_date.iso8601 unless ENV['INGEST_ALL']
+      end
     end
 
     def set_specs


### PR DESCRIPTION
Enables selective harvesting based on [changes in CDMBL](https://github.com/Minitex/cdmbl/pull/1).

By default, the weekly indexing job will now selectively query CDM for records that have changed in the last 8 days. To index the full collection without time restriction, set the `INGEST_ALL` environment variable:

```bash
INGEST_ALL=1 bundle exec rake mdl_ingester:collections
```