### PR TITLE
Send errors to Sentry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,3 +87,5 @@ gem 'whenever', '0.9.7', :require => false
 # Autmatically link URLs in citation details
 gem 'rinku', '2.0.2'
 gem 'redis-rails', '5.0.2'
+
+gem 'sentry-raven'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -365,6 +365,8 @@ GEM
     selenium-webdriver (3.142.2)
       childprocess (>= 0.5, < 2.0)
       rubyzip (~> 1.2, >= 1.2.2)
+    sentry-raven (2.13.0)
+      faraday (>= 0.7.6, < 1.0)
     sidekiq (5.2.7)
       connection_pool (~> 2.2, >= 2.2.2)
       rack (>= 1.5.0)
@@ -497,6 +499,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   selenium-webdriver
+  sentry-raven
   sidekiq (= 5.2.7)
   sidekiq-failures (= 1.0.0)
   sinatra (= 2.0.4)


### PR DESCRIPTION
Add sentry-raven to report errors.

The current Sentry server isn't currently accepting requests to the
`/envelope` endpoint, which is what is used by the newer `sentry-ruby`
library, but we can use `sentry-raven` for the time being.

Requires the `SENTRY_DSN` environment variable to enable error
reporting.