### PR TITLE
Allow self-service indexing without any date restriction

### DIFF
--- a/app/controllers/indexing_controller.rb
+++ b/app/controllers/indexing_controller.rb
@@ -40,9 +40,13 @@ class IndexingController < ApplicationController
   end
 
   def etl_config
-    MDL::ETL.new.config.merge(
-      set_spec: params.require(:collection),
-      from: Date.parse(params.require(:date)).iso8601
-    )
+    collection = params.require(:collection)
+    MDL::ETL.new.config.merge(set_spec: collection).tap do |config|
+      if params[:date].empty?
+        config.delete(:from)
+      else
+        config[:from] = Date.parse(params[:date]).iso8601
+      end
+    end
   end
 end

--- a/app/views/indexing/index.html.erb
+++ b/app/views/indexing/index.html.erb
@@ -12,9 +12,12 @@
 
     <div class="form-group row">
       <%= form.label 'Changed since', class: 'col-sm-2 control-label' %>
-      <div class="col-sm-4">
-        <%= form.date_field :date, max: Date.current, required: true %>
+      <div class="col-sm-2 mx-sm-3">
+        <%= form.date_field :date, max: Date.current, aria: { describedby: 'date-help-text' } %>
       </div>
+      <small id="date-help-text" class="text-muted">
+        Leave blank to index without any date restriction.
+      </small>
     </div>
     <%= form.submit 'Start', class: 'btn btn-default' %>
   <% end %>


### PR DESCRIPTION
The date field is no longer required, and leaving it blank will remove any date restriction on indexing.