### PR TITLE
Check authorization for self-service indexing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,6 +73,7 @@ gem 'chosen-rails', '~> 1.9'
 gem 'rsolr', '2.0.2'
 gem 'globalid', '0.4.2'
 gem 'webpacker', '2.0'
+gem 'cancancan', '~> 3.2.1'
 
 # # CONTENTdm ETL
 gem 'devise', '4.6.2'
@@ -82,7 +83,7 @@ gem 'cdmbl', '0.18.0'
 gem 'sidekiq', '5.2.7'
 gem 'sinatra', '2.0.4', require: false
 gem 'sidekiq-failures', '1.0.0'
-gem 'whenever', '0.9.7', :require => false
+gem 'whenever', '0.9.7', require: false
 
 # Autmatically link URLs in citation details
 gem 'rinku', '2.0.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,7 @@ GEM
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
     builder (3.2.4)
+    cancancan (3.2.1)
     capistrano (3.8.2)
       airbrussh (>= 1.0.0)
       i18n
@@ -466,6 +467,7 @@ DEPENDENCIES
   blacklight_advanced_search (~> 6.4)
   blacklight_oai_provider (~> 6.0)
   blacklight_range_limit (~> 6.5)
+  cancancan (~> 3.2.1)
   capistrano (~> 3.6)
   capistrano-bundler (~> 1.1.2)
   capistrano-passenger

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,17 @@
 class ApplicationController < ActionController::Base
-  # Adds a few additional behaviors into the application controller 
+  # Adds a few additional behaviors into the application controller
   include Blacklight::Controller
   layout 'blacklight'
 
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+
+  rescue_from CanCan::AccessDenied do |exception|
+    respond_to do |format|
+      format.json { head :forbidden, content_type: 'text/html' }
+      format.html { redirect_to main_app.root_url, notice: exception.message }
+      format.js   { head :forbidden, content_type: 'text/html' }
+    end
+  end
 end

--- a/app/controllers/indexing_controller.rb
+++ b/app/controllers/indexing_controller.rb
@@ -1,5 +1,6 @@
 class IndexingController < ApplicationController
   before_action :authenticate_user!
+  before_action :check_authorization
 
   FACET_FIELD = 'oai_set_ssi'.freeze
 
@@ -44,5 +45,9 @@ class IndexingController < ApplicationController
       set_spec: params.require(:collection),
       from: Date.parse(params.require(:date)).iso8601
     )
+  end
+
+  def check_authorization
+    authorize! :index, :collections
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+    user ||= User.new
+
+    if user.admin?
+      can :manage, :all
+    end
+    # Define abilities for the passed in user here. For example:
+    #
+    #   user ||= User.new # guest user (not logged in)
+    #   if user.admin?
+    #     can :manage, :all
+    #   else
+    #     can :read, :all
+    #   end
+    #
+    # The first argument to `can` is the action you are giving the user
+    # permission to do.
+    # If you pass :manage it will apply to every action. Other common actions
+    # here are :read, :create, :update and :destroy.
+    #
+    # The second argument is the resource the user can perform the action on.
+    # If you pass :all it will apply to every resource. Otherwise pass a Ruby
+    # class of the resource.
+    #
+    # The third argument is an optional hash of conditions to further filter the
+    # objects.
+    # For example, here the user can only update published articles.
+    #
+    #   can :update, Article, :published => true
+    #
+    # See the wiki for details:
+    # https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,7 +31,7 @@ class User < ActiveRecord::Base
   end
 
   def admin?
-      roles.include? 'admin'
+    roles.include? 'admin'
   end
 
   def roles

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,12 @@
 FactoryGirl.define do
   factory :user do
-    
+    email { Faker::Internet.email }
+    password { 'password' }
+
+    trait :admin do
+      after(:build) do |user|
+        user.roles = ['admin']
+      end
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+require 'cancan/matchers'
+
+describe User do
+  describe 'authorization' do
+    subject(:ability) { Ability.new(user) }
+
+    context 'without roles' do
+      let(:user) { User.new }
+      it { is_expected.to_not be_able_to(:index, :collections) }
+    end
+
+    context 'with admin role' do
+      let(:user) do
+        User.new.tap { |u| u.roles = ['admin'] }
+      end
+
+      it { is_expected.to be_able_to(:index, :collections) }
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -50,6 +50,7 @@ ActiveRecord::Migration.maintain_test_schema!
 RSpec.configure do |config|
 
   config.include FactoryGirl::Syntax::Methods
+  config.include Devise::Test::IntegrationHelpers, type: :request
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"

--- a/spec/requests/indexing_spec.rb
+++ b/spec/requests/indexing_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe 'self-service indexing' do
+  it 'is available to admins' do
+    user = create(:user, :admin)
+    sign_in(user)
+    get '/indexing'
+
+    expect(response).to have_http_status(:ok)
+  end
+
+  it 'is not available to non-admins' do
+    user = create(:user)
+    sign_in(user)
+    get '/indexing'
+
+    expect(response).to have_http_status(:found)
+  end
+end


### PR DESCRIPTION
This adds an authorization library and uses it to enforce authorization on the self-service indexing controller. We'll need to assign the admin role to any users who need to use it.