### PR TITLE
Notify Sentry when ETL starts and finishes

### DIFF
--- a/app/models/indexing_run.rb
+++ b/app/models/indexing_run.rb
@@ -1,0 +1,3 @@
+class IndexingRun < ActiveRecord::Base
+  has_many :jobs, dependent: :destroy
+end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -1,0 +1,4 @@
+class Job < ActiveRecord::Base
+  belongs_to :indexing_run
+  validates :job_id, presence: true
+end

--- a/app/services/mdl/job_auditing.rb
+++ b/app/services/mdl/job_auditing.rb
@@ -1,0 +1,49 @@
+module MDL
+  module EtlAuditing
+    JobNotYetCreatedError = Class.new(StandardError)
+
+    module ClassMethods
+      def perform_async(*args)
+        jid = super
+        ###
+        # TODO: update CDMBL so jobs have a reference to an indexing run
+        # rather than assume the last one is the one we care about. This
+        # will work, though, unless we start running multiple indexing
+        # runs at the same time.
+        IndexingRun.last.jobs.create!(job_id: jid)
+        jid
+      end
+    end
+
+    def self.prepended(base)
+      class << base
+        prepend ClassMethods
+      end
+    end
+
+    def perform(*args)
+      ###
+      # The job can be picked up by a worker before the Job record
+      # is even created. If that happens, raise an exception to
+      # trigger Sidekiq's retry logic. JobNotYetCreatedError is
+      # ignored by Sentry, so it won't be noisy.
+      job = Job.find_by(job_id: self.jid) || raise(JobNotYetCreatedError)
+      indexing_run = job.indexing_run
+
+      super
+
+      job.update(completed_at: Time.current)
+      notify_complete if indexing_finished?(indexing_run)
+    end
+
+    private
+
+    def notify_complete
+      Raven.send_event(Raven::Event.new(message: 'ETL Finished'))
+    end
+
+    def indexing_finished?(indexing_run)
+      indexing_run.jobs.where(completed_at: nil).none?
+    end
+  end
+end

--- a/config/initializers/cdmbl.rb
+++ b/config/initializers/cdmbl.rb
@@ -27,6 +27,8 @@ module CDMBL
       Rails.logger.info "CDMBL: Loading #{ingestables.length} records and deleting #{deletables.length}"
     end
   end
+
+  LoadWorker.prepend(MDL::EtlAuditing)
 end
 
 ###

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,3 @@
+Raven.configure do |config|
+  config.excluded_exceptions += [MDL::EtlAuditing::JobNotYetCreatedError]
+end

--- a/db/migrate/20210411202118_create_jobs.rb
+++ b/db/migrate/20210411202118_create_jobs.rb
@@ -1,0 +1,11 @@
+class CreateJobs < ActiveRecord::Migration[5.2]
+  def change
+    create_table :jobs do |t|
+      t.references :indexing_run
+      t.string :job_id, null: false, index: true
+      t.datetime :completed_at, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_14_191244) do
+ActiveRecord::Schema.define(version: 2021_04_11_202118) do
 
   create_table "bookmarks", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -26,6 +26,17 @@ ActiveRecord::Schema.define(version: 2019_05_14_191244) do
   create_table "indexing_runs", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "jobs", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+    t.bigint "indexing_run_id"
+    t.string "job_id", null: false
+    t.datetime "completed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["completed_at"], name: "index_jobs_on_completed_at"
+    t.index ["indexing_run_id"], name: "index_jobs_on_indexing_run_id"
+    t.index ["job_id"], name: "index_jobs_on_job_id"
   end
 
   create_table "searches", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/lib/mdl/etl_worker.rb
+++ b/lib/mdl/etl_worker.rb
@@ -1,5 +1,6 @@
 require 'cdmbl'
 require 'mdl/transformer'
+require 'mdl/job_auditing'
 
 module MDL
   ###
@@ -81,18 +82,19 @@ module MDL
   end
 
   class TransformWorker < CDMBL::TransformWorker
+    prepend EtlAuditing
+
     def transformer_klass
       @transformer_klass ||= CompoundAggregatingTransformer
     end
   end
 
   class ETLWorker < CDMBL::ETLWorker
-    def transform_worker_klass
-      @transform_worker_klass ||= TransformWorker
-    end
+    prepend EtlAuditing
 
-    def etl_worker_klass
-      @etl_worker_klass ||= self.class
+    def initialize
+      @transform_worker_klass = TransformWorker
+      @etl_worker_klass = self.class
     end
   end
 end

--- a/lib/tasks/ingester.rake
+++ b/lib/tasks/ingester.rake
@@ -29,6 +29,8 @@ namespace :mdl_ingester do
 
   def run_etl!(set_specs = [])
     puts "Indexing Sets: '#{set_specs.join(', ')}'"
+    IndexingRun.create!
+    Raven.send_event(Raven::Event.new(message: 'ETL Started'))
     CDMBL::ETLBySetSpecs.new(
       set_specs: set_specs,
       etl_config: config,


### PR DESCRIPTION
This change adds Sentry notification for when the ETL process begins and ends. The ETL task spawns many asynchronous Sidekiq jobs, so we need to track these in the database to know when they've all successfully completed. For a full indexing (_not_ selective harvesting) of the catalog, this amounts to around 48k jobs. Actual indexing should create far fewer jobs, and since we do this only once a week, I don't imagine that the new `jobs` table will grow so quickly that it will be a problem. Of course, we can create a follow up job to clear out the table on some interval if that ever becomes an issue.