### PR TITLE
Use the correct task name in cron schedule

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -27,7 +27,7 @@ end
 # Pick up new CDM records daily
 every :friday, at: '11pm' do
   runner 'Index All Items (from all collections)'
-  rake 'ingest:collections'
+  rake 'mdl_ingester:collections'
 end
 
 every 1.day, at: '12:00am' do


### PR DESCRIPTION
The schedule file (used to write the crontab on deployment) has the wrong rake task name for indexing the collections every week. This updates that to use the correct name.