### PR TITLE
Kaltura playlist

### DIFF
--- a/app/helpers/mdl_blacklight_helper.rb
+++ b/app/helpers/mdl_blacklight_helper.rb
@@ -65,7 +65,7 @@ module MdlBlacklightHelper
       anchor = '/kaltura_audio_playlist'
     end
 
-    if anchor == '/kaltura_video' && doc['kaltura_video_playlist_ssi']
+    if anchor == '/kaltura_video' && (doc['kaltura_video_playlist_ssi'] || doc['kaltura_audio_playlist_ssi'])
       anchor = '/kaltura_video_playlist'
     end
 

--- a/app/services/mdl/job_auditing.rb
+++ b/app/services/mdl/job_auditing.rb
@@ -22,12 +22,7 @@ module MDL
     end
 
     def perform(*args)
-      ###
-      # The job can be picked up by a worker before the Job record
-      # is even created. If that happens, raise an exception to
-      # trigger Sidekiq's retry logic. JobNotYetCreatedError is
-      # ignored by Sentry, so it won't be noisy.
-      job = Job.find_by(job_id: self.jid) || raise(JobNotYetCreatedError)
+      job = Job.find_by(job_id: self.jid) || job_not_found.call
       indexing_run = job.indexing_run
 
       super
@@ -37,6 +32,24 @@ module MDL
     end
 
     private
+
+    def job_not_found
+      if Rails.env.test?
+        ###
+        # Sidekiq's retry logic is off the table in the test environment,
+        # and we rely on that for our Sentry notifications. So, if we're
+        # in test, we'll fake it 'till we make it since we don't want to
+        # notify Sentry anyway.
+        proc { IndexingRun.last.jobs.create!(job_id: self.jid) }
+      else
+        ###
+        # The job can be picked up by a worker before the Job record
+        # is even created. If that happens, raise an exception to
+        # trigger Sidekiq's retry logic. JobNotYetCreatedError is
+        # ignored by Sentry, so it won't be noisy.
+        proc { raise(JobNotYetCreatedError) }
+      end
+    end
 
     def notify_complete
       Raven.send_event(Raven::Event.new(message: 'ETL Finished'))

--- a/lib/mdl/borealis_video.rb
+++ b/lib/mdl/borealis_video.rb
@@ -1,16 +1,15 @@
 module MDL
-  class BorealisVideo <  BorealisAsset
-
+  class BorealisVideo < BorealisAsset
     def src
       "http://cdm16022.contentdm.oclc.org/utils/getstream/collection/#{collection}/id/#{id}"
     end
 
     def downloads
-        []
+      []
     end
 
     def type
-      (video_playlist_id) ? 'kaltura_video_playlist' : 'kaltura_video'
+      (playlist_id) ? 'kaltura_video_playlist' : 'kaltura_video'
     end
 
     def video_id
@@ -21,9 +20,16 @@ module MDL
       document.fetch('kaltura_video_playlist_ssi', false)
     end
 
+    def audio_playlist_id
+      document.fetch('kaltura_audio_playlist_ssi', false)
+    end
+
+    def playlist_id
+      video_playlist_id || audio_playlist_id
+    end
+
     def viewer
       MDL::BorealisVideoPlayer
     end
-
   end
 end

--- a/lib/mdl/borealis_video_player.rb
+++ b/lib/mdl/borealis_video_player.rb
@@ -1,7 +1,7 @@
 module MDL
   class BorealisVideoPlayer < BorealisAssetsViewer
     def to_viewer
-      (asset.video_playlist_id) ? playlist : player
+      (asset.playlist_id) ? playlist : player
     end
 
     def player
@@ -29,7 +29,7 @@ module MDL
         'uiconf_id' => 38719361,
         'flashvars' => {
           'streamerType' => 'auto',
-          'playlistAPI.kpl0Id' => asset.video_playlist_id,
+          'playlistAPI.kpl0Id' => asset.playlist_id,
         },
         'transcript' => {
           'texts' => asset.transcripts,

--- a/spec/features/advanced_search_spec.rb
+++ b/spec/features/advanced_search_spec.rb
@@ -12,6 +12,7 @@ describe 'advanced search' do
     end
 
     it 'can find a record by text contained in its transcript' do
+      pending 'Transcript is temporarily excluded from advanced search'
       visit '/'
       click_link 'Advanced Search'
       fill_in 'Transcript', with: '"fifty percent cut"'

--- a/spec/fixtures/vcr_cassettes/ingest_otter_297.yml
+++ b/spec/fixtures/vcr_cassettes/ingest_otter_297.yml
@@ -98,7 +98,7 @@ http_interactions:
   recorded_at: Mon, 04 Jan 2021 01:51:33 GMT
 - request:
     method: get
-    uri: http://cdm16022.contentdm.oclc.org/oai/oai.php?verb=ListSets
+    uri: https://cdm16022.contentdm.oclc.org/oai/oai.php?verb=ListSets
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/lib/mdl/borealis_document_spec.rb
+++ b/spec/lib/mdl/borealis_document_spec.rb
@@ -13,19 +13,96 @@ require_relative '../../../lib/mdl/borealis_ppt.rb'
 module MDL
   describe BorealisDocument do
     let(:asset_klass) { double }
-    let(:document) { {'id' => 'foo:123', 'format' => 'image/jp2', 'title_ssi' => 'blerg'} }
-    let(:compound_document) { document.merge({'compound_objects_ts' =>
-        '[{"pageptr" : 123, "title" : "Some thing", "transc" : "blah", "pagefile" : "foo.jp2"},
-         {"pageptr" : 321, "title" : "Another Thing", "transc" : "The text", "pagefile" : "foo.mp4"}]'}) }
-
-    let(:bogus_pagefile) { document.merge({'compound_objects_ts' =>
-        '[{"pageptr" : 123, "title" : "Some thing", "transc" : "blah", "pagefile" : {}},
-         {"pageptr" : 321, "title" : "Another Thing", "transc" : "The text", "pagefile" : "foo.jp2"}]'}) }
+    let(:document) do
+      {'id' => 'foo:123', 'format' => 'image/jp2', 'title_ssi' => 'blerg'}
+    end
+    let(:compound_document) do
+      document.merge('compound_objects_ts' => <<~JSON
+        [
+          {
+            "pageptr": 123,
+            "title": "Some thing",
+            "transc": "blah",
+            "pagefile": "foo.jp2"
+          },
+          {
+            "pageptr": 321,
+            "title": "Another Thing",
+            "transc": "The text",
+            "pagefile": "foo.mp4"
+          }
+        ]
+      JSON
+      )
+    end
+    let(:bogus_pagefile) do
+      document.merge('compound_objects_ts' => <<~JSON
+        [
+          {
+            "pageptr": 123,
+            "title": "Some thing",
+            "transc": "blah",
+            "pagefile": {}
+          },
+         {
+            "pageptr": 321,
+            "title": "Another Thing",
+            "transc": "The text",
+            "pagefile": "foo.jp2"
+          }
+        ]
+      JSON
+      )
+    end
 
     context 'when the document is a single item' do
       it 'correctly serializes the document' do
         expect(BorealisDocument.new(document: document).to_viewer).to eq (
-          {"image"=>{"viewerColumnsSmall"=>"col-xs-12 col-sm-8", "sidebarColumnsLarge"=>"col-xs-12 col-sm-4", "viewerColumnsLarge"=>"col-xs-12 col-sm-9", "sidebarColumnsSmall"=>"col-xs-12 col-sm-3", "type"=>"image", "basename"=>"image", "thumbnail"=>"/thumbnails/foo:123", "label"=>"Image", "transcripts"=>[], "osdConfig"=>{"setStrings"=>[{:name=>"Tooltips.Home", :value=>"Reset"}], "include_controls"=>true, "sequenceMode"=>true, "showReferenceStrip"=>false, "defaultZoomLevel"=>0, :minZoomLevel=>0, "tileSources"=>["/contentdm-images/info?id=foo:123"]}, "getImageURL"=>"https://cdm16022.contentdm.oclc.org/utils/ajaxhelper", "pages"=>[{:id=>"123", :collection=>"foo", :transcripts=>[], :transcript=>"blerg \n ", :title=>"blerg", :assets=>[], :thumbnail=>"/thumbnails/foo:123", "id"=>0, "viewer"=>"OSD_VIEWER", "cdmCollection"=>"foo", "cdmIdentifier"=>"123", "sidebarThumbnail"=>"/thumbnails/foo:123", "infoURL"=>"https://cdm16022.contentdm.oclc.org/digital/iiif/foo/123/info.json"}], "transcript"=>{"texts"=>[], "label"=>"Image"}}}
+          {
+            "image"=>{
+              "viewerColumnsSmall"=>"col-xs-12 col-sm-8",
+              "sidebarColumnsLarge"=>"col-xs-12 col-sm-4",
+              "viewerColumnsLarge"=>"col-xs-12 col-sm-9",
+              "sidebarColumnsSmall"=>"col-xs-12 col-sm-3",
+              "type"=>"image",
+              "basename"=>"image",
+              "thumbnail"=>"/thumbnails/foo:123",
+              "label"=>"Image",
+              "transcripts"=>[],
+              "osdConfig"=>{
+                "setStrings"=>[{:name=>"Tooltips.Home", :value=>"Reset"}],
+                "include_controls"=>true,
+                "sequenceMode"=>true,
+                "showReferenceStrip"=>false,
+                "defaultZoomLevel"=>0,
+                :minZoomLevel=>0,
+                "tileSources"=>["/contentdm-images/info?id=foo:123"]
+              },
+              "getImageURL"=>"https://cdm16022.contentdm.oclc.org/utils/ajaxhelper",
+              "pages"=>[
+                {
+                  :id=>"123",
+                  :collection=>"foo",
+                  :transcripts=>[],
+                  :transcript=>"blerg \n ",
+                  :title=>"blerg",
+                  :subtitle=>nil,
+                  :assets=>[],
+                  :thumbnail=>"/thumbnails/foo:123",
+                  "id"=>0,
+                  "viewer"=>"OSD_VIEWER",
+                  "cdmCollection"=>"foo",
+                  "cdmIdentifier"=>"123",
+                  "sidebarThumbnail"=>"/thumbnails/foo:123",
+                  "infoURL"=>"https://cdm16022.contentdm.oclc.org/digital/iiif/foo/123/info.json"
+                }
+              ],
+              "transcript"=>{
+                "texts"=>[],
+                "label"=>"Image"
+              }
+            }
+          }
         )
       end
     end
@@ -35,18 +112,83 @@ module MDL
         expect(BorealisDocument.new(document: compound_document).to_viewer).to eq (
           {
             "image"=> {
-              "viewerColumnsSmall"=>"col-xs-12 col-sm-8", "sidebarColumnsLarge"=>"col-xs-12 col-sm-4", "viewerColumnsLarge"=>"col-xs-12 col-sm-9", "sidebarColumnsSmall"=>"col-xs-12 col-sm-3", "type"=>"image", "basename"=>"image", "thumbnail"=>"/thumbnails/foo:123", "label"=>"Image", "transcripts"=>["blah"], "osdConfig"=>{"setStrings"=>[{:name=>"Tooltips.Home", :value=>"Reset"}], "include_controls"=>true, "sequenceMode"=>true, "showReferenceStrip"=>false, "defaultZoomLevel"=>0, :minZoomLevel=>0, "tileSources"=>["/contentdm-images/info?id=foo:123"]}, "getImageURL"=>"https://cdm16022.contentdm.oclc.org/utils/ajaxhelper", "pages"=>[{:id=>123, :collection=>"foo", :transcripts=>["blah"], :transcript=>"Some thing \n blah", :title=>"Some thing", :assets=>[], :thumbnail=>"/thumbnails/foo:123", "id"=>0, "viewer"=>"OSD_VIEWER", "cdmCollection"=>"foo", "cdmIdentifier"=>123, "sidebarThumbnail"=>"/thumbnails/foo:123", "infoURL"=>"https://cdm16022.contentdm.oclc.org/digital/iiif/foo/123/info.json"}], "transcript"=>{"texts"=>["blah"], "label"=>"Image"}
+              "viewerColumnsSmall"=>"col-xs-12 col-sm-8",
+              "sidebarColumnsLarge"=>"col-xs-12 col-sm-4",
+              "viewerColumnsLarge"=>"col-xs-12 col-sm-9",
+              "sidebarColumnsSmall"=>"col-xs-12 col-sm-3",
+              "type"=>"image",
+              "basename"=>"image",
+              "thumbnail"=>"/thumbnails/foo:123",
+              "label"=>"Image",
+              "transcripts"=>["blah"],
+              "osdConfig"=>{
+                "setStrings"=>[{:name=>"Tooltips.Home", :value=>"Reset"}],
+                "include_controls"=>true,
+                "sequenceMode"=>true,
+                "showReferenceStrip"=>false,
+                "defaultZoomLevel"=>0,
+                :minZoomLevel=>0,
+                "tileSources"=>["/contentdm-images/info?id=foo:123"]
+              },
+              "getImageURL"=>"https://cdm16022.contentdm.oclc.org/utils/ajaxhelper",
+              "pages"=>[
+                {
+                  :id=>123,
+                  :collection=>"foo",
+                  :transcripts=>["blah"],
+                  :transcript=>"Some thing \n blah",
+                  :title=>"Some thing",
+                  :subtitle=>nil,
+                  :assets=>[],
+                  :thumbnail=>"/thumbnails/foo:123",
+                  "id"=>0,
+                  "viewer"=>"OSD_VIEWER",
+                  "cdmCollection"=>"foo",
+                  "cdmIdentifier"=>123,
+                  "sidebarThumbnail"=>"/thumbnails/foo:123",
+                  "infoURL"=>"https://cdm16022.contentdm.oclc.org/digital/iiif/foo/123/info.json"
+                }
+              ],
+              "transcript"=>{"texts"=>["blah"],
+              "label"=>"Image"}
             },
             "kaltura_video"=> {
-              "type"=>"kaltura_video", "targetId"=>"kaltura_player_video", "wid"=>"_1369852", "uiconf_id"=>38683631, "transcript"=>{"texts"=>["The text"], "label"=>"Video"}, "entry_id"=>false, "wrapper_height"=>"100%", "wrapper_width"=>"100%", "thumbnail"=>"https://d1kue88aredzk1.cloudfront.net/video-1.png"
+              "type"=>"kaltura_video",
+              "targetId"=>"kaltura_player_video",
+              "wid"=>"_1369852",
+              "uiconf_id"=>38683631,
+              "transcript"=>{"texts"=>["The text"],
+              "label"=>"Video"},
+              "entry_id"=>false,
+              "wrapper_height"=>"100%",
+              "wrapper_width"=>"100%",
+              "thumbnail"=>"https://d1kue88aredzk1.cloudfront.net/video-1.png"
             }
           }
         )
       end
 
       it 'rejects bad page page file data' do
-        expect(BorealisDocument.new(document: bogus_pagefile).to_viewer['image']['pages']).to eq(
-          [{:id=>321,:collection=>"foo", :transcripts=>["The text"], :transcript=>"Another Thing \n The text", :title=>"Another Thing", :assets=>[], :thumbnail=>"/thumbnails/foo:321", "id"=>0, "viewer"=>"OSD_VIEWER", "cdmCollection"=>"foo", "cdmIdentifier"=>321, "sidebarThumbnail"=>"/thumbnails/foo:321", "infoURL"=>"https://cdm16022.contentdm.oclc.org/digital/iiif/foo/321/info.json"}]
+        pages = BorealisDocument.new(document: bogus_pagefile).to_viewer['image']['pages']
+        expect(pages).to eq(
+          [
+            {
+              :id=>321,
+              :collection=>"foo",
+              :transcripts=>["The text"],
+              :transcript=>"Another Thing \n The text",
+              :title=>"Another Thing",
+              :subtitle=>nil,
+              :assets=>[],
+              :thumbnail=>"/thumbnails/foo:321",
+              "id"=>0,
+              "viewer"=>"OSD_VIEWER",
+              "cdmCollection"=>"foo",
+              "cdmIdentifier"=>321,
+              "sidebarThumbnail"=>"/thumbnails/foo:321",
+              "infoURL"=>"https://cdm16022.contentdm.oclc.org/digital/iiif/foo/321/info.json"
+            }
+          ]
         )
       end
     end

--- a/spec/lib/mdl/borealis_open_seadragon_spec.rb
+++ b/spec/lib/mdl/borealis_open_seadragon_spec.rb
@@ -12,14 +12,98 @@ module MDL
         BorealisImage.new(collection: 'foo', id: '321', title: 'Page Three', transcript: 'Page Three stuff here')
       ]
     end
-
     let(:openseadragon) { BorealisOpenSeadragon.new(assets: images) }
+
     it 'correctly identifies its src' do
       expect(openseadragon.to_viewer).to eq (
-        {"viewerColumnsSmall"=>"col-xs-12 col-sm-8", "sidebarColumnsLarge"=>"col-xs-12 col-sm-4", "viewerColumnsLarge"=>"col-xs-12 col-sm-9", "sidebarColumnsSmall"=>"col-xs-12 col-sm-3", "type"=>"image", "basename"=>"image", "thumbnail"=>"/thumbnails/foo:123", "label"=>"Image", "transcripts"=>["Page One stuff here", "Page Two stuff here", "Page Three stuff here"], "osdConfig"=>{"setStrings"=>[{:name=>"Tooltips.Home", :value=>"Reset"}], "include_controls"=>true, "sequenceMode"=>true, "showReferenceStrip"=>false, "defaultZoomLevel"=>0, :minZoomLevel=>0, "tileSources"=>["/contentdm-images/info?id=foo:123", "/contentdm-images/info?id=foo:312", "/contentdm-images/info?id=foo:321"]}, "getImageURL"=>"https://cdm16022.contentdm.oclc.org/utils/ajaxhelper", "pages"=>[{:id=>"123", :collection=>"foo", :transcripts=>["Page One stuff here"], :transcript=>"Page One \n Page One stuff here", :title=>"Page One", :assets=>[], :thumbnail=>"/thumbnails/foo:123", "id"=>0, "viewer"=>"OSD_VIEWER", "cdmCollection"=>"foo", "cdmIdentifier"=>"123", "sidebarThumbnail"=>"/thumbnails/foo:123", "infoURL"=>"https://cdm16022.contentdm.oclc.org/digital/iiif/foo/123/info.json"}, {:id=>"312", :collection=>"foo", :transcripts=>["Page Two stuff here"], :transcript=>"Page Two \n Page Two stuff here", :title=>"Page Two", :assets=>[], :thumbnail=>"/thumbnails/foo:312", "id"=>1, "viewer"=>"OSD_VIEWER", "cdmCollection"=>"foo", "cdmIdentifier"=>"312", "sidebarThumbnail"=>"/thumbnails/foo:312", "infoURL"=>"https://cdm16022.contentdm.oclc.org/digital/iiif/foo/312/info.json"}, {:id=>"321", :collection=>"foo", :transcripts=>["Page Three stuff here"], :transcript=>"Page Three \n Page Three stuff here", :title=>"Page Three", :assets=>[], :thumbnail=>"/thumbnails/foo:321", "id"=>2, "viewer"=>"OSD_VIEWER", "cdmCollection"=>"foo", "cdmIdentifier"=>"321", "sidebarThumbnail"=>"/thumbnails/foo:321", "infoURL"=>"https://cdm16022.contentdm.oclc.org/digital/iiif/foo/321/info.json"}], "transcript"=>{"texts"=>["Page One stuff here", "Page Two stuff here", "Page Three stuff here"], "label"=>"Image"}}
+        {
+          "viewerColumnsSmall"=>"col-xs-12 col-sm-8",
+          "sidebarColumnsLarge"=>"col-xs-12 col-sm-4",
+          "viewerColumnsLarge"=>"col-xs-12 col-sm-9",
+          "sidebarColumnsSmall"=>"col-xs-12 col-sm-3",
+          "type"=>"image",
+          "basename"=>"image",
+          "thumbnail"=>"/thumbnails/foo:123",
+          "label"=>"Image",
+          "transcripts"=>[
+            "Page One stuff here",
+            "Page Two stuff here",
+            "Page Three stuff here"
+          ],
+          "osdConfig"=>{
+            "setStrings"=>[{:name=>"Tooltips.Home", :value=>"Reset"}],
+            "include_controls"=>true,
+            "sequenceMode"=>true,
+            "showReferenceStrip"=>false,
+            "defaultZoomLevel"=>0,
+            :minZoomLevel=>0,
+            "tileSources"=>[
+              "/contentdm-images/info?id=foo:123",
+              "/contentdm-images/info?id=foo:312",
+              "/contentdm-images/info?id=foo:321"
+            ]
+          },
+          "getImageURL"=>"https://cdm16022.contentdm.oclc.org/utils/ajaxhelper",
+          "pages"=>[
+            {
+              :id=>"123",
+              :collection=>"foo",
+              :transcripts=>["Page One stuff here"],
+              :transcript=>"Page One \n Page One stuff here",
+              :title=>"Page One",
+              :subtitle=>nil,
+              :assets=>[],
+              :thumbnail=>"/thumbnails/foo:123",
+              "id"=>0,
+              "viewer"=>"OSD_VIEWER",
+              "cdmCollection"=>"foo",
+              "cdmIdentifier"=>"123",
+              "sidebarThumbnail"=>"/thumbnails/foo:123",
+              "infoURL"=>"https://cdm16022.contentdm.oclc.org/digital/iiif/foo/123/info.json"
+            },
+            {
+              :id=>"312",
+              :collection=>"foo",
+              :transcripts=>["Page Two stuff here"],
+              :transcript=>"Page Two \n Page Two stuff here",
+              :title=>"Page Two",
+              :subtitle=>nil,
+              :assets=>[],
+              :thumbnail=>"/thumbnails/foo:312",
+              "id"=>1,
+              "viewer"=>"OSD_VIEWER",
+              "cdmCollection"=>"foo",
+              "cdmIdentifier"=>"312",
+              "sidebarThumbnail"=>"/thumbnails/foo:312",
+              "infoURL"=>"https://cdm16022.contentdm.oclc.org/digital/iiif/foo/312/info.json"
+            },
+            {
+              :id=>"321",
+              :collection=>"foo",
+              :transcripts=>["Page Three stuff here"],
+              :transcript=>"Page Three \n Page Three stuff here",
+              :title=>"Page Three",
+              :subtitle=>nil,
+              :assets=>[],
+              :thumbnail=>"/thumbnails/foo:321",
+              "id"=>2,
+              "viewer"=>"OSD_VIEWER",
+              "cdmCollection"=>"foo",
+              "cdmIdentifier"=>"321",
+              "sidebarThumbnail"=>"/thumbnails/foo:321",
+              "infoURL"=>"https://cdm16022.contentdm.oclc.org/digital/iiif/foo/321/info.json"
+            }
+          ],
+          "transcript"=>{
+            "texts"=>[
+              "Page One stuff here",
+              "Page Two stuff here",
+              "Page Three stuff here"
+            ],
+            "label"=>"Image"
+          }
+        }
       )
     end
-
   end
 end
-

--- a/spec/lib/mdl/borealis_video_player_spec.rb
+++ b/spec/lib/mdl/borealis_video_player_spec.rb
@@ -4,33 +4,69 @@ require_relative '../../../lib/mdl/borealis_video_player.rb'
 require_relative '../../../lib/mdl/borealis_video.rb'
 module MDL
   describe BorealisVideoPlayer do
-    let(:video) do
-      instance_double('BorealisVideo',
-                      type: 'kaltura_video',
-                      transcripts: ['A brief history of cat costumes'],
-                      thumbnail: 'https://d1kue88aredzk1.cloudfront.net/video-3.png',
-                      video_id: 'v568')
-    end
+    describe '#to_viewer' do
+      subject(:viewer_config) do
+        BorealisVideoPlayer.new(assets: [video]).to_viewer
+      end
 
-    it 'produces a configuration for Videos' do
-      expect(video).to receive(:transcripts)
-      expect(video).to receive(:video_playlist_id)
-      expect(viewer(video)).to be_kind_of(Hash)
-      expect(viewer(video)['type']).to eq 'kaltura_video'
-      expect(viewer(video)['targetId']).to eq 'kaltura_player_video'
-      expect(viewer(video)['wid']).to eq '_1369852'
-      expect(viewer(video)['uiconf_id']).to eq 38683631
-      expect(viewer(video)['entry_id']).to eq 'v568'
-      expect(viewer(video)['transcript']).to eq(
-        'texts' => ['A brief history of cat costumes'], 'label' => 'Video'
-      )
-      expect(viewer(video)['wrapper_height']).to eq '100%'
-      expect(viewer(video)['wrapper_width']).to eq '100%'
-      expect(viewer(video)['thumbnail']).to eq 'https://d1kue88aredzk1.cloudfront.net/video-1.png'
-    end
+      context 'when the asset type is "kaltura_video"' do
+        let(:video) do
+          instance_double(
+            'BorealisVideo',
+            type: 'kaltura_video',
+            transcripts: ['A brief history of cat costumes'],
+            thumbnail: 'https://d1kue88aredzk1.cloudfront.net/video-3.png',
+            video_id: 'v568',
+            playlist_id: nil
+          )
+        end
 
-    def viewer(asset)
-      @viewer ||= BorealisVideoPlayer.new(assets: [asset]).to_viewer
+        it 'produces a video configuration' do
+          expect(viewer_config['type']).to eq 'kaltura_video'
+          expect(viewer_config['targetId']).to eq 'kaltura_player_video'
+          expect(viewer_config['wid']).to eq '_1369852'
+          expect(viewer_config['uiconf_id']).to eq 38683631
+          expect(viewer_config['entry_id']).to eq 'v568'
+          expect(viewer_config['transcript']).to eq(
+            'texts' => ['A brief history of cat costumes'],
+            'label' => 'Video'
+          )
+          expect(viewer_config['wrapper_height']).to eq '100%'
+          expect(viewer_config['wrapper_width']).to eq '100%'
+          expect(viewer_config['thumbnail']).to eq 'https://d1kue88aredzk1.cloudfront.net/video-1.png'
+        end
+      end
+
+      context 'when the asset type is "kaltura_video_playlist"' do
+        let(:video) do
+          instance_double(
+            'BorealisVideo',
+            type: 'kaltura_video_playlist',
+            playlist_id: 'video123',
+            transcripts: ['A brief history of cat costumes'],
+            thumbnail: 'https://d1kue88aredzk1.cloudfront.net/video-3.png',
+            video_id: 'v568'
+          )
+        end
+
+        it 'produces a video playlist configuration' do
+          expect(viewer_config['type']).to eq 'kaltura_video_playlist'
+          expect(viewer_config['targetId']).to eq 'kaltura_player_playlist'
+          expect(viewer_config['wid']).to eq '_1369852'
+          expect(viewer_config['uiconf_id']).to eq 38719361
+          expect(viewer_config['flashvars']).to eq(
+            'streamerType' => 'auto',
+            'playlistAPI.kpl0Id' => 'video123'
+          )
+          expect(viewer_config['transcript']).to eq(
+            'texts' => ['A brief history of cat costumes'],
+            'label' => 'Video Playlist'
+          )
+          expect(viewer_config['wrapper_height']).to eq '100%'
+          expect(viewer_config['wrapper_width']).to eq '100%'
+          expect(viewer_config['thumbnail']).to eq 'https://d1kue88aredzk1.cloudfront.net/video-1.png'
+        end
+      end
     end
   end
 end

--- a/spec/lib/mdl/borealis_video_spec.rb
+++ b/spec/lib/mdl/borealis_video_spec.rb
@@ -4,10 +4,17 @@ require_relative '../../../lib/mdl/borealis_video.rb'
 require_relative '../../../lib/mdl/borealis_video_player.rb'
 module MDL
   describe BorealisVideo do
-    let(:video) do
-      BorealisVideo.new(document: { 'kaltura_video_ssi' => '1234' },
-                        collection: 'foo', id: '124')
+    let(:document) do
+      { 'kaltura_video_ssi' => '1234' }
     end
+    subject(:video) do
+      BorealisVideo.new(
+        document: document,
+        collection: 'foo',
+        id: '124'
+      )
+    end
+
     it 'provides a download link' do
       expect(video.downloads).to eq []
     end
@@ -20,12 +27,61 @@ module MDL
       expect(video.viewer).to be MDL::BorealisVideoPlayer
     end
 
-    it 'knows its type' do
-      expect(video.type).to eq 'kaltura_video'
-    end
-
     it 'knows its video_id' do
       expect(video.video_id).to eq '1234'
+    end
+
+    describe '#playlist_id' do
+      context 'when the document has a video playlist ID' do
+        let(:document) do
+          super().merge('kaltura_video_playlist_ssi' => 'video123')
+        end
+
+        it 'returns the video playlist ID' do
+          expect(video.playlist_id).to eq('video123')
+        end
+      end
+
+      context 'when the document has an audio playlist ID' do
+        let(:document) do
+          super().merge('kaltura_audio_playlist_ssi' => 'audio123')
+        end
+
+        it 'returns the audio playlist ID' do
+          expect(video.playlist_id).to eq('audio123')
+        end
+      end
+
+      context 'when the document has both video and audio playlist IDs' do
+        let(:document) do
+          super().merge(
+            'kaltura_video_playlist_ssi' => 'video123',
+            'kaltura_audio_playlist_ssi' => 'audio123'
+          )
+        end
+
+        it 'returns the video playlist ID' do
+          expect(video.playlist_id).to eq('video123')
+        end
+      end
+    end
+
+    describe '#type' do
+      context 'when it has a playlist_id' do
+        let(:document) do
+          super().merge('kaltura_video_playlist_ssi' => 'video123')
+        end
+
+        it 'returns "kaltura_video_playlist"' do
+          expect(video.type).to eq 'kaltura_video_playlist'
+        end
+      end
+
+      context 'when it does not have a playlist_id' do
+        it 'returns "kaltura_video"' do
+          expect(video.type).to eq 'kaltura_video'
+        end
+      end
     end
   end
 end

--- a/spec/lib/mdl/thumbnail_spec.rb
+++ b/spec/lib/mdl/thumbnail_spec.rb
@@ -26,7 +26,7 @@ describe MDL::Thumbnail do
 
   it 'returns a filepath' do
     thumb = MDL::Thumbnail.new(collection:'mpls', id: '13128', cache_dir: tmpdir, type: 'Moving Image')
-    expect(thumb.file_path).to eq '/app/tmp/mpls_13128.jpg'
+    expect(thumb.file_path).to eq "#{Rails.root}/tmp/mpls_13128.jpg"
   end
 
   it 'returns a filename' do
@@ -53,6 +53,4 @@ describe MDL::Thumbnail do
       expect(subject.cached_file).to eq File.read(tmpfilepath)
     end
   end
-
-
 end

--- a/spec/support/ingestion.rb
+++ b/spec/support/ingestion.rb
@@ -2,7 +2,8 @@ module Ingestion
   module_function
 
   def ingest_record(id)
-    MDL::TransformWorker.new.perform(
+    worker = setup_worker
+    worker.perform(
       [id.split(':')],
       { url: config[:solr_config][:url] },
       config[:cdm_endpoint],
@@ -19,5 +20,15 @@ module Ingestion
 
   def config
     @config ||= etl.config
+  end
+
+  def setup_worker
+    run = IndexingRun.create!
+    worker = MDL::TransformWorker.new
+    worker.jid = SecureRandom.hex
+    run.jobs.create!(
+      job_id: worker.jid
+    )
+    worker
   end
 end


### PR DESCRIPTION
Allow video playlists to be recognized by their audio_playlist_id

Because of how indexing is setup, documents that are video playlists
will occasionally have an audio_playlist_id
(kaltura_audio_playlist_ssi), instead of a video_playlist_id
(kaltura_video_playlist_ssi). With this change, we'll correctly detect
this expected scenario, and render the appropriate viewer configuration.

Addresses #51 