### PR TITLE
Get batch delete job working

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,7 +79,7 @@ gem 'cancancan', '~> 3.2.1'
 gem 'devise', '4.6.2'
 gem 'devise-guests', '0.6.0'
 gem 'hash_at_path', '0.1.6'
-gem 'cdmbl', '0.18.0'
+gem 'cdmbl', github: 'Minitex/cdmbl', tag: 'v0.19.0'
 gem 'sidekiq', '5.2.7'
 gem 'sinatra', '2.0.4', require: false
 gem 'sidekiq-failures', '1.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,16 @@
+GIT
+  remote: https://github.com/Minitex/cdmbl.git
+  revision: 2d655e72ebcbb439c9cb8f22e550c2037b178b8d
+  tag: v0.19.0
+  specs:
+    cdmbl (0.19.0)
+      activesupport (>= 4.2)
+      contentdm_api (~> 0.5.0)
+      hash_at_path (~> 0.1)
+      rsolr (~> 2.0)
+      sidekiq (>= 3.5)
+      titleize (~> 1.4)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -103,13 +116,6 @@ GEM
       regexp_parser (~> 1.2)
       uglifier
       xpath (~> 3.2)
-    cdmbl (0.18.0)
-      activesupport (>= 4.2)
-      contentdm_api (~> 0.5.0)
-      hash_at_path (~> 0.1)
-      rsolr (~> 2.0)
-      sidekiq (>= 3.5)
-      titleize (~> 1.4)
     childprocess (1.0.1)
       rake (< 13.0)
     chosen-rails (1.9.0)
@@ -472,7 +478,7 @@ DEPENDENCIES
   capistrano-rails
   capistrano-sidekiq
   capybara
-  cdmbl (= 0.18.0)
+  cdmbl!
   chosen-rails (~> 1.9)
   coffee-rails (~> 4.2)
   coveralls

--- a/config/initializers/cdmbl.rb
+++ b/config/initializers/cdmbl.rb
@@ -28,6 +28,19 @@ module CDMBL
     end
   end
 
+  class BatchDeletedCallback
+    def self.call!(deleter)
+      Rails.logger.info "CDMBL: Deleted #{deleter.deletables.size} records in batch of #{deleter.batch_size}, beginning at offset #{deleter.start}"
+    end
+  end
+
+  class BatchDeleteJobCompletedCallback
+    def self.call!
+      Rails.logger.info "CDMBL: Batch delete job complete"
+      Raven.send_event(Raven::Event.new(message: 'Batch delete job complete'))
+    end
+  end
+
   LoadWorker.prepend(MDL::EtlAuditing)
 end
 

--- a/lib/tasks/ingester.rake
+++ b/lib/tasks/ingester.rake
@@ -15,12 +15,14 @@ namespace :mdl_ingester do
     run_etl!(etl.set_specs)
   end
 
-  desc "delete batches of unpublished records"
+  desc "Delete records from Solr that are no longer in CONTENTdm"
   ##
   # e.g. rake mdl_ingester:delete
-  task :delete do
+  task delete: [:environment] do
+    Raven.send_event(Raven::Event.new(message: 'Batch delete job started'))
     CDMBL::BatchDeleterWorker.perform_async(
       0,
+      50,
       'oai:cdm16022.contentdm.oclc.org:',
       config[:oai_endpoint],
       config[:solr_config][:url]


### PR DESCRIPTION
Update CDMBL to the latest version, now pulling from Github instead of
Rubygems. With this change, we can run `rake mdl_ingester:delete` to 
prune any records that exist in Solr but not in CONTENTdm. We'll notify
Sentry when the job begins, and again when it completes.

Companion to https://github.com/Minitex/cdmbl/pull/2

Addresses #124 