### PR TITLE
Provide more context and consistency to ETL notifications

### DIFF
--- a/app/services/mdl/etl.rb
+++ b/app/services/mdl/etl.rb
@@ -17,6 +17,19 @@ module MDL
       @set_spec_filter  = set_spec_filter
     end
 
+    def run(set_specs: [], from: nil)
+      IndexingRun.create!
+      msg_which = set_specs.size > 1 ? "#{set_specs.size} collections" : set_specs.first
+      msg_from = from ? "from #{from}" : ''
+      message = "ETL Started for #{msg_which} #{msg_from}".rstrip
+      Raven.send_event(Raven::Event.new(message: message))
+      CDMBL::ETLBySetSpecs.new(
+        set_specs: set_specs,
+        etl_config: config.tap { |c| c.merge!(from: from) if from },
+        etl_worker_klass: MDL::ETLWorker
+      ).run!
+    end
+
     def config
       {
         oai_endpoint: oai_endpoint,

--- a/lib/tasks/ingester.rake
+++ b/lib/tasks/ingester.rake
@@ -29,13 +29,9 @@ namespace :mdl_ingester do
 
   def run_etl!(set_specs = [])
     puts "Indexing Sets: '#{set_specs.join(', ')}'"
-    IndexingRun.create!
-    Raven.send_event(Raven::Event.new(message: 'ETL Started'))
-    CDMBL::ETLBySetSpecs.new(
-      set_specs: set_specs,
-      etl_config: config,
-      etl_worker_klass: MDL::ETLWorker
-    ).run!
+    args = { set_specs: set_specs }
+    args[:from] = 8.days.ago.to_date.iso8601 unless ENV['INGEST_ALL']
+    etl.run(args)
   end
 
   desc 'Launch a background job to index a single record.'


### PR DESCRIPTION
With this change, we'll consistently notify Sentry of ETL jobs
regardless of whether they're scheduled via Cron or manually kicked off
via the UI. Additionally, we'll include more context in the event
message, such as which collection (if just one) and date was used for
selective harvesting

Addresses #142 