### PR TITLE
Commit Solr updates after indexing run completes

### DIFF
--- a/app/services/mdl/job_auditing.rb
+++ b/app/services/mdl/job_auditing.rb
@@ -28,7 +28,10 @@ module MDL
       super
 
       job.update(completed_at: Time.current)
-      notify_complete if indexing_finished?(indexing_run)
+      if indexing_finished?(indexing_run)
+        notify_complete
+        SolrClient.new.commit
+      end
     end
 
     private

--- a/lib/tasks/ingester.rake
+++ b/lib/tasks/ingester.rake
@@ -38,6 +38,7 @@ namespace :mdl_ingester do
 
   desc 'Launch a background job to index a single record.'
   task :record, [:id] => :environment  do |t, args|
+    IndexingRun.create!
     MDL::TransformWorker.perform_async(
       [args[:id].split(':')],
       { url: config[:solr_config][:url]},


### PR DESCRIPTION
This will commit Solr updates when an indexing run completes.