### PR TITLE
Allow for pruning stale records by collection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,7 +80,7 @@ gem 'devise', '4.6.2'
 gem 'devise-guests', '0.6.0'
 gem 'hash_at_path', github: 'UMNLibraries/hash_at_path', ref: '92dafd3b06de2cbc861b9ad80dcadb3ed7274597'
 gem 'contentdm_api', github: 'UMNLibraries/contentdm_api', ref: '847a70689813c03990db2ebb622d0beee7657688'
-gem 'cdmbl', github: 'Minitex/cdmbl', tag: 'v0.19.0'
+gem 'cdmbl', github: 'Minitex/cdmbl', tag: 'v0.20.0'
 gem 'sidekiq', '5.2.7'
 gem 'sinatra', '2.0.4', require: false
 gem 'sidekiq-failures', '1.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/Minitex/cdmbl.git
-  revision: 2d655e72ebcbb439c9cb8f22e550c2037b178b8d
-  tag: v0.19.0
+  revision: dfc471819b95a868f99c14a9348116868d229a6d
+  tag: v0.20.0
   specs:
-    cdmbl (0.19.0)
+    cdmbl (0.20.0)
       activesupport (>= 4.2)
       contentdm_api (~> 0.5.0)
       hash_at_path (~> 0.1)

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,0 +1,1 @@
+Redis.exists_returns_integer = true

--- a/lib/tasks/ingester.rake
+++ b/lib/tasks/ingester.rake
@@ -19,14 +19,8 @@ namespace :mdl_ingester do
   ##
   # e.g. rake mdl_ingester:delete
   task delete: [:environment] do
-    Raven.send_event(Raven::Event.new(message: 'Batch delete job started'))
-    CDMBL::BatchDeleterWorker.perform_async(
-      0,
-      50,
-      'oai:cdm16022.contentdm.oclc.org:',
-      config[:oai_endpoint],
-      config[:solr_config][:url]
-    )
+    puts '[DEPRECATED] please switch to `rake prune:all`'
+    Rake::Task['prune:all'].invoke
   end
 
   def run_etl!(set_specs = [])

--- a/lib/tasks/prune.rake
+++ b/lib/tasks/prune.rake
@@ -1,0 +1,31 @@
+namespace :prune do
+  desc "Remove Solr records that are no longer in CONTENTdm"
+  task all: [:environment] do
+    do_prune
+  end
+
+  desc "Remove Solr records in the given collection that are no longer in CONTENTdm"
+  task :collection, [:set_spec] => :environment do |t, args|
+    do_prune(solr_query: "setspec_ssi:#{args[:set_spec]}")
+  end
+
+  def do_prune(solr_query: nil)
+    Raven.send_event(Raven::Event.new(message: 'Batch delete job started'))
+    CDMBL::BatchDeleterWorker.perform_async(
+      0,
+      50,
+      'oai:cdm16022.contentdm.oclc.org:',
+      config[:oai_endpoint],
+      config[:solr_config][:url],
+      solr_query
+    )
+  end
+
+  def config
+    etl.config
+  end
+
+  def etl
+    @etl ||= MDL::ETL.new
+  end
+end


### PR DESCRIPTION
This deprecates the existing `mdl_ingester:delete` Rake task and renames
it to `prune:all`. There is another task in the `prune` namespace, which
allows for pruning records by collection. This task is
`prune:collection` and it takes a collection/setspec as an argument.

Usage:

  `rake prune:collection[sll]`

Requires CDMBL changes here: https://github.com/Minitex/cdmbl/pull/3

Addresses #145