### PR TITLE
Include anchor in gallery view image links

### DIFF
--- a/app/helpers/mdl_blacklight_helper.rb
+++ b/app/helpers/mdl_blacklight_helper.rb
@@ -52,9 +52,21 @@ module MdlBlacklightHelper
       label = index_presenter(doc).label field
     end
 
-    link_to raw(label),
-            url_for(controller: 'catalog', action: 'show', id: doc.id, anchor: build_anchor(doc)),
-            document_link_params(doc, opts).merge(data: { turbolinks: false })
+    document_show_link(document: doc, label: label, **opts)
+  end
+
+  def document_show_link(document:, label:, **opts)
+    link_to(
+      raw(label),
+      url_for(
+        controller: 'catalog',
+        action: 'show',
+        id: document.id,
+        anchor: build_anchor(document)
+      ),
+      document_link_params(document, opts)
+        .merge(data: { turbolinks: false })
+    )
   end
 
   private

--- a/app/views/catalog/_index_gallery_default.html.erb
+++ b/app/views/catalog/_index_gallery_default.html.erb
@@ -2,11 +2,17 @@
 <div class="panel panel-default gallery-result">
   <div class="panel-body">
     <div class="image-wrapper">
-      <%= link_to raw(cached_thumbnail_tag(document)), "/catalog/#{document['id']}?", counter: counter %>
+      <%=
+        document_show_link(
+          document: document,
+          label: cached_thumbnail_tag(document),
+          counter: counter
+        )
+      %>
     </div>
     <div class="title">
       <% document['title_ssi'] = truncate(document['title_ssi'], length: 50) %>
-      <%=  link_to_document document, document_show_link_field(document), counter: counter %>
+      <%= link_to_document document, document_show_link_field(document), counter: counter %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Links on the images in the gallery view didn't include the anchor. This makes sure they do.

Addresses #147 