### PR TITLE
Use GitHub for homegrown libs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,7 +78,8 @@ gem 'cancancan', '~> 3.2.1'
 # # CONTENTdm ETL
 gem 'devise', '4.6.2'
 gem 'devise-guests', '0.6.0'
-gem 'hash_at_path', '0.1.6'
+gem 'hash_at_path', github: 'UMNLibraries/hash_at_path', ref: '92dafd3b06de2cbc861b9ad80dcadb3ed7274597'
+gem 'contentdm_api', github: 'UMNLibraries/contentdm_api', ref: '847a70689813c03990db2ebb622d0beee7657688'
 gem 'cdmbl', github: 'Minitex/cdmbl', tag: 'v0.19.0'
 gem 'sidekiq', '5.2.7'
 gem 'sinatra', '2.0.4', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,21 @@ GIT
       sidekiq (>= 3.5)
       titleize (~> 1.4)
 
+GIT
+  remote: https://github.com/UMNLibraries/contentdm_api.git
+  revision: 847a70689813c03990db2ebb622d0beee7657688
+  ref: 847a70689813c03990db2ebb622d0beee7657688
+  specs:
+    contentdm_api (0.5.0)
+      http (~> 4.0.3)
+
+GIT
+  remote: https://github.com/UMNLibraries/hash_at_path.git
+  revision: 92dafd3b06de2cbc861b9ad80dcadb3ed7274597
+  ref: 92dafd3b06de2cbc861b9ad80dcadb3ed7274597
+  specs:
+    hash_at_path (0.1.6)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -133,8 +148,6 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.8)
     connection_pool (2.2.3)
-    contentdm_api (0.5.0)
-      http (~> 4.0.3)
     coveralls (0.8.21)
       json (>= 1.8, < 3)
       simplecov (~> 0.14.1)
@@ -181,7 +194,6 @@ GEM
       rubyzip (~> 1.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    hash_at_path (0.1.6)
     hashdiff (0.3.4)
     http (4.0.5)
       addressable (~> 2.3)
@@ -481,6 +493,7 @@ DEPENDENCIES
   cdmbl!
   chosen-rails (~> 1.9)
   coffee-rails (~> 4.2)
+  contentdm_api!
   coveralls
   database_cleaner
   devise (= 4.6.2)
@@ -489,7 +502,7 @@ DEPENDENCIES
   faker
   fontello_rails_converter
   globalid (= 0.4.2)
-  hash_at_path (= 0.1.6)
+  hash_at_path!
   jbuilder (~> 2.0)
   jquery-rails
   listen (>= 3.0.5, < 3.2)


### PR DESCRIPTION
Use GitHub repos rather than Rubygems for in-house libraries. This will prevent us from needing to maintain a pool of gem publishers in order to make updates.

Addresses #140 