### PR TITLE
Include webpack bundles in blacklight layout

### DIFF
--- a/app/views/layouts/blacklight.html.erb
+++ b/app/views/layouts/blacklight.html.erb
@@ -37,6 +37,7 @@
     <%= javascript_include_tag "application" %>
     <%= csrf_meta_tags %>
     <%= content_for(:head) %>
+    <%= content_for(:webpack_bundles) %>
 </head>
 
   <body class="<%= render_body_class %>">


### PR DESCRIPTION
To avoid conflicts with Spotlight assets, it was necessary to
conditionally include the Spotlight assets depending on whether or not
we had `content_for?(:webpack_bundles)`. However, when we are rendering
views in a regular search context, we use the Blacklight layout, so we
must also render any webpack bundles within this layout as well.