### PR TITLE
Fix rendering of search results gallery view

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -139,8 +139,6 @@ class CatalogController < ApplicationController
     ###
     # Spotlight additions
     config.view.gallery.partials += [:index_header]
-    config.view.masonry.partials = [:index]
-    config.view.slideshow.partials = [:index]
     config.show.oembed_field = :oembed_url_ssm
     config.show.partials.insert(1, :oembed)
     config.show.tile_source_field = :content_metadata_image_iiif_info_ssm

--- a/app/views/catalog/_document_gallery.html.erb
+++ b/app/views/catalog/_document_gallery.html.erb
@@ -1,0 +1,4 @@
+<% # Overrides partial from blacklight-gallery gem -%>
+<div id="documents" class="documents-gallery">
+  <%= render_gallery_collection documents %>
+</div>

--- a/app/views/catalog/_index_gallery.html.erb
+++ b/app/views/catalog/_index_gallery.html.erb
@@ -1,0 +1,3 @@
+<div class="document">
+  <%= render partial: 'catalog/index_gallery_default', locals: { document: document, document_counter: document_counter } %>
+</div>


### PR DESCRIPTION
This fixes the rendering of search results in gallery view. There were some structural and class naming changes as a result of including the `blacklight-gallery` gem, which is a Spotlight dependency.