### PR TITLE
Change how we send messages to Sentry

### DIFF
--- a/app/services/mdl/etl.rb
+++ b/app/services/mdl/etl.rb
@@ -22,7 +22,7 @@ module MDL
       msg_which = set_specs.size > 1 ? "#{set_specs.size} collections" : set_specs.first
       msg_from = from ? "from #{from}" : ''
       message = "ETL Started for #{msg_which} #{msg_from}".rstrip
-      Raven.send_event(Raven::Event.new(message: message))
+      Raven.capture_message(message)
       CDMBL::ETLBySetSpecs.new(
         set_specs: set_specs,
         etl_config: config.tap { |c| c.merge!(from: from) if from },

--- a/app/services/mdl/job_auditing.rb
+++ b/app/services/mdl/job_auditing.rb
@@ -55,7 +55,7 @@ module MDL
     end
 
     def notify_complete
-      Raven.send_event(Raven::Event.new(message: 'ETL Finished'))
+      Raven.capture_message('ETL Finished')
     end
 
     def indexing_finished?(indexing_run)

--- a/config/initializers/cdmbl.rb
+++ b/config/initializers/cdmbl.rb
@@ -37,7 +37,7 @@ module CDMBL
   class BatchDeleteJobCompletedCallback
     def self.call!
       Rails.logger.info "CDMBL: Batch delete job complete"
-      Raven.send_event(Raven::Event.new(message: 'Batch delete job complete'))
+      Raven.capture_event('Batch delete job complete')
     end
   end
 


### PR DESCRIPTION
Our sentry-raven gem was updated to version 3.1.2 in September, a change
that requires us to alter how we send messages to Sentry. This change
updates the three call sites that currently are sending messages so that
they use the new API.