### PR TITLE
Update Kaltura URLs for A/V assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ Run the setup script (builds Docker images for dependencies)
 ./local-dev-init.sh
 ```
 
+Start Sidekiq
+
+```bash
+./start_sidekiq.sh 'default -q iiif_search -q critical,2'
+```
+
 [Ingest some content](https://github.com/Minitex/mdl_search/wiki/Development-Environment-Setup#ingest-some-content)
 
 ## Interacting with the App on the Command Line
@@ -121,7 +127,7 @@ $ docker rm $(docker ps -a | grep Exited | awk '\''BEGIN { FS=" " } ; {print $1;
 $ docker rmi $(docker images | grep "^<none>" | awk "{print $3}")
 ```
 
-## Usefull Tools
+## Useful Tools
 
 * [Docker Dive](https://github.com/wagoodman/dive)
 

--- a/lib/mdl/borealis_audio.rb
+++ b/lib/mdl/borealis_audio.rb
@@ -1,7 +1,7 @@
 module MDL
   class BorealisAudio < BorealisAsset
     def src(entry_id = audio_id)
-      "http://cdnbakmi.kaltura.com/p/1369852/sp/136985200/playManifest/entryId/#{entry_id.strip}/flavorId/1_atuqqpf6/format/url/protocol/http/a.mp4"
+      "https://cdnapisec.kaltura.com/p/1369852/sp/136985200/playManifest/entryId/#{entry_id.strip}/flavorId/1_atuqqpf6/format/url/protocol/http/a.mp4"
     end
 
     def thumbnail_url

--- a/lib/mdl/borealis_video.rb
+++ b/lib/mdl/borealis_video.rb
@@ -2,7 +2,7 @@ module MDL
   class BorealisVideo < BorealisAsset
     def src(entry_id = nil)
       entry_id ||= (playlist_id || video_id)
-      "http://cdnbakmi.kaltura.com/p/1369852/sp/136985200/playManifest/entryId/#{entry_id.strip}/flavorId/1_uivmmxof/format/url/protocol/http/a.mp4"
+      "https://cdnapisec.kaltura.com/p/1369852/sp/136985200/playManifest/entryId/#{entry_id.strip}/flavorId/1_uivmmxof/format/url/protocol/http/a.mp4"
     end
 
     def thumbnail_url

--- a/prep_uv.sh
+++ b/prep_uv.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set -e
-
 cp -R node_modules/universalviewer/dist public/uv
 rm public/uv/*.zip
 cp config/uv-config.json.example public/uv/config.json

--- a/spec/lib/mdl/borealis_video_spec.rb
+++ b/spec/lib/mdl/borealis_video_spec.rb
@@ -20,7 +20,7 @@ module MDL
     end
 
     it 'knows its src' do
-      expect(video.src).to eq 'http://cdnbakmi.kaltura.com/p/1369852/sp/136985200/playManifest/entryId/1234/flavorId/1_uivmmxof/format/url/protocol/http/a.mp4'
+      expect(video.src).to eq 'https://cdnapisec.kaltura.com/p/1369852/sp/136985200/playManifest/entryId/1234/flavorId/1_uivmmxof/format/url/protocol/http/a.mp4'
     end
 
     it 'knows its player' do


### PR DESCRIPTION
We need to use an HTTPS URL for the assets in order to reliably load
content across browsers (mixed content is handled differently in Chrome
and Firefox, for instance). Firefox will warn, but load the insecure
content anyway, whereas Chrome will upgrade the request to HTTPS
automatically. The problem there, however, is that there is no valid SSL
certificate for the Kaltura domain we had been using. By using this new
URL, we can avoid the situation entirely.