### PR TITLE
Improve heuristics around when to index for IIIF search

### DIFF
--- a/lib/mdl/queue_iiif_search_processing.rb
+++ b/lib/mdl/queue_iiif_search_processing.rb
@@ -9,10 +9,28 @@ module MDL
   class QueueIiifSearchProcessing
     class << self
       def format(doc)
-        if [doc, *Array(doc['page'])].any? { |p| p['transc'].present? }
+        if iiif_search_candidate?(doc)
           IiifSearchProcessingWorker.perform_async(doc['id'].sub('/', ':'))
         end
         nil
+      end
+
+      private
+
+      def iiif_search_candidate?(doc)
+        has_ocr?(doc) || text_type?(doc) || ocr_candidate?(doc)
+      end
+
+      def has_ocr?(doc)
+        [doc, *Array(doc['page'])].any? { |p| p['cdmhasocr'] == '1' }
+      end
+
+      def text_type?(doc)
+        doc['type'] == 'Text'
+      end
+
+      def ocr_candidate?(doc)
+        doc['format'] == 'image/jp2' && (doc['transc'].present? || doc['transl'].present?)
       end
     end
   end

--- a/spec/fixtures/contentdm/audio.yml
+++ b/spec/fixtures/contentdm/audio.yml
@@ -1,0 +1,671 @@
+---
+title: Interview with Naomi Silfversten and Ruth Silfversten Coppins
+photog: Silfversten, Naomi; Coppins Silfversten Ruth
+contri: {}
+descri: 'Beginning in 1998, the City of Duluth (Minn.) Sister Cities Commission collaborated
+  with the Iron Range Research Center to record a series of oral history interviews.
+  Independent scholar Dr. JoAnn Hanson-Stone acted as the lead interviewer. The voluntary,
+  self-selecting participants were second-generation Swedish Americans whose parents
+  settled in northeast Minnesota in the early 1900s. The interviews were initiated
+  to create supplementary material for a planned exhibit, "A Long Way Home: Swedish
+  Immigrant Life in Duluth and Northeast Minnesota, 1890-1940."'
+dat: '1998-01-29'
+publia: {}
+dimens: '01:02:14'
+genera: Immigration and Ethnicity
+type: Sound Recording-Nonmusical
+physic: Oral histories;
+specif: 'Swedish Americans; Immigrants; '
+subjec: Swedish-American experience
+city: {}
+county: {}
+state: Minnesota
+countr: United States
+geogra: {}
+geonam: {}
+langua: English
+par: {}
+contra: 'Iron Range Research Center '
+contac: Minnesota Discovery Center, 1005 Discovery Drive, Chisholm, Minnesota 55719
+  http://mndiscoverycenter.com/research-center
+righta: {}
+rightc: In Copyright
+rights: http://rightsstatements.org/vocab/InC/1.0/
+rightd: This Item is protected by copyright and/or related rights. You are free to
+  use this Item in any way that is permitted by the copyright and related rights legislation
+  that applies to your use. For other uses you need to obtain permission from the
+  rights-holder(s).
+public: {}
+identi: irrc_1999_3834
+resour: {}
+audio: 1_i1bal3lz
+audioa: {}
+video: {}
+projec: Minnesota Digital Library 2013-2015
+fiscal: Minnesota Immigrants is made possible through the generous funding of the
+  Digital Public Library of America Digital Hubs Pilot, which is supported by the
+  Digital Public Library of America with funding provided by the National Endowment
+  for the Humanities and the John S. and James L. Knight Foundation.
+publis: {}
+date: {}
+format: {}
+digspe: {}
+digspa: {}
+digspb: {}
+digspc: {}
+digspd: {}
+digspf: {}
+digspg: {}
+digsph: {}
+digspi: {}
+digspj: {}
+digspk: {}
+transc: {}
+transl: {}
+fullrs: {}
+find: 1195.cpd
+dmaccess: {}
+dmimage: {}
+dmcreated: '2021-07-09'
+dmmodified: '2021-07-09'
+dmoclcno: {}
+dmrecord: '1194'
+restrictionCode: '1'
+cdmfilesize: '326'
+cdmfilesizeformatted: 0.00 MB
+cdmprintpdf: '0'
+cdmhasocr: '0'
+cdmisnewspaper: '0'
+page:
+- pagetitle: Audio
+  pagefile: 1193.mp3
+  pageptr: '1192'
+  title: Audio
+  photog: {}
+  contri: {}
+  descri: {}
+  dat: {}
+  publia: {}
+  dimens: {}
+  genera: {}
+  type: {}
+  physic: {}
+  specif: {}
+  subjec: {}
+  city: {}
+  county: {}
+  state: {}
+  countr: {}
+  geogra: {}
+  geonam: {}
+  langua: {}
+  par: {}
+  contra: {}
+  contac: {}
+  righta: {}
+  rightc: {}
+  rights: {}
+  rightd: {}
+  public: {}
+  identi: {}
+  resour: {}
+  audio: {}
+  audioa: {}
+  video: {}
+  projec: {}
+  fiscal: {}
+  publis: {}
+  date: {}
+  format: {}
+  digspe: {}
+  digspa: {}
+  digspb: {}
+  digspc: {}
+  digspd: {}
+  digspf: {}
+  digspg: {}
+  digsph: {}
+  digspi: {}
+  digspj: {}
+  digspk: {}
+  transc: {}
+  transl: {}
+  fullrs: {}
+  find: 1193.mp3
+  dmaccess: {}
+  dmimage: {}
+  dmcreated: '2021-07-09'
+  dmmodified: '2021-07-09'
+  dmoclcno: {}
+  dmrecord: '1192'
+  restrictionCode: '1'
+  cdmfilesize: '22271'
+  cdmfilesizeformatted: 0.02 MB
+  cdmprintpdf: '0'
+  cdmhasocr: '0'
+  cdmisnewspaper: '0'
+  page: []
+  id: p16022coll548/1192
+- pagetitle: Transcript
+  pagefile: 1194.pdf
+  pageptr: '1193'
+  title: Transcript
+  photog: {}
+  contri: {}
+  descri: {}
+  dat: {}
+  publia: {}
+  dimens: {}
+  genera: {}
+  type: {}
+  physic: {}
+  specif: {}
+  subjec: {}
+  city: {}
+  county: {}
+  state: {}
+  countr: {}
+  geogra: {}
+  geonam: {}
+  langua: {}
+  par: {}
+  contra: {}
+  contac: {}
+  righta: {}
+  rightc: {}
+  rights: {}
+  rightd: {}
+  public: {}
+  identi: {}
+  resour: {}
+  audio: {}
+  audioa: {}
+  video: {}
+  projec: {}
+  fiscal: {}
+  publis: {}
+  date: {}
+  format: {}
+  digspe: {}
+  digspa: {}
+  digspb: {}
+  digspc: {}
+  digspd: {}
+  digspf: {}
+  digspg: {}
+  digsph: {}
+  digspi: {}
+  digspj: {}
+  digspk: {}
+  transc: |
+    DATE
+    SUBJECT
+    INTERVIEWER
+    PROGRAM
+    Swedish Immigrant Oral History Project
+    Naomi Silfversten, Ruth Silfversten Coppins, Betty Hamspen
+    January 29, 1998
+    Page 1
+    : January 29, 1998
+    : Interview with Naomi Silfversten, Ruth Silfversten Coppins,
+    and Betty Hamsten, Duluth, Minnesota
+    : Ed Nelson
+    : Swedish Immigrant Oral History Project
+    City of Duluth Sister Cities Commission
+    My name is Ed Nelson and we're at the office of the Senior Reporter in Duluth,
+    Minnesota. This is an interview with Naomi Silfversten, and Ruth Silfversten Coppins,
+    petty Hamspen, Ruth and Naomi are sisters and they grew up in the West End of
+    Duluth and your father's name was Carl J. Silfversten.
+    Can you give me a background on where your father and mother were born and how
+    they came to this country?
+    My father was born in the Swedish section or part of Finland and the town was Narpes,
+    Finland. Mother was born in Sweden, Skane. (with an umlaut, I think.)
+    Mother's name?
+    Ellen Benson.
+    Wilen were they born?
+    M9ther was born in 1883. I remember that. Because she was 95 just about 96 when she died
+    and that was in 1979.
+    Was your father older than your mother?
+    Yes, about 4 years or so - so 1879.
+    They immigrated - stories?
+    Well, Dad was 19 years old when he came here and he wanted to go into the ministry
+    eventually so he had to go to school and I believe he probably came from Rock Island or that
+    area and I don't know much about the - after 19 I suppose he had to get - he had an education
+    in Finland and they came here because he did get to Gustavus Adolphus College and from
+    there he went to Theological Seminary; that was in Rockford. This is where he met Mother as
+    she was a member ofthe church and the choir and they were married.
+    Did he tell you about life in Finland?
+    Swedish Immigrant Oral History Project
+    Naomi Silfversten, Ruth Silfversten Coppins, Betty Hamspen
+    January 29, 1998
+    Page 2
+    No but - well I'm quite sure he was a poor child and like so many immigrants because they
+    wanted to get a better - have a better life so he was interested in becoming a minister and this
+    was his goal to come to this country to study.
+    Was his father a minister?
+    No, his father was a captain ofthe high seas or a fisherman - a commercial fisherman on the
+    gulfof 01 so Dad was sort of raised to be a fisherman when he was a child so Dad has
+    written several books but he has that one that is a safe channel that he writes stories regarding
+    the - ofthe days with his dad fishing.
+    I am pretty sure I have that at home.
+    I have that one too. And I don't have much on my mother's background. Apparently she was
+    just a baby when she came here to this country.
+    So your father was a Swede-Finn?
+    Dad always said Finland Swede and - Swedes are born iii Finland and which is - I had made
+    a trip there- it would be ten years this year and I visited the area where Dad was from and it's
+    on the west coast - the GulfofB.? -and I don't know how many towns or cities are included
+    in all ofthe west coast but it does go up quite a ways and I don't have that map with me. It's
+    Finland and all outside on the west coast ofFinland.
+    It was settled by Swedish people?
+    Yes.
+    Finnish government?
+    I suppose they had to be. Part ofthe time they were undertheRussian - in 1917 then Finland
+    declared its independence.
+    Were they amongst Swedish speaking people?
+    Oh yes the whole area is. Jim was on that trip too.
+    When your father came here did he come by himself?
+    I understand that.
+    Any relatives?
+    Not that I'm aware of. Not that we know.
+    Swedish Immigrant Oral History Project .
+    Naomi Silfversten, Ruth Silfversten Coppins, Betty Hamspen
+    January 29, 1998
+    Page 3
+    We had relatives way up in T., He didn't come over the same time she did and
+    whether she was born over there or in this country - I don't know. That is the only known
+    relative I can think of.
+    When did he come here?
+    1819.
+    What did he do when he first came here?
+    I suppose he had to go on in school, I don't know ifhe completed high school in Finland so
+    called- he probably did but then he went to Gustavus College in the summer he used to - in
+    fact he came to Duluth. I remember him telling us in 1905 and he worked on the coal docks
+    in order to get some money for school and at that time he also - he didn't join but he would
+    go to the Bethany Lutheran church in West End and I think he taught Saturday Bible School­something
+    like that and ~ but and then from then he ofcourse
+    When did he meet your mother?
+    When they probably came to S.? in that area. I don't know much about them landing here. I
+    know that she was - well he was at this church in Chicago because she was from Chicago and
+    he met her at church naturally because he was interested in becoming a minister and she­mother
+    was in the choir and so apparently the romance started that way and so they were
+    married and then - married in Chicago.
+    So he graduated from Gustavus and went on to Augustana Seminary in Rock Island, IL.
+    Graduated?
+    It must have been 1909 because it seemed to me they were married in 1909.... Church? The
+    first church he was assigned to was in Worchester, Massachusetts, and then from there they
+    moved to Gladstone, ML He was a SwedishlFinland minister. He had these churches that
+    were Swede/Finn origin and then went to Gladstone, ML, went to Ironwood, Michigan, then
+    to Rhinelander, WI and then ofcourse in 1920 he was called here to Bethel,
+    Did he stay in Duluth?
+    Yes until he passed away. He was the pastor ofthis church for 26 years.
+    Where were you guys born?
+    I was born in Ironwood.
+    I was born in Rhinelander and our brother was born in Gladstone.
+    Swedish Immigrant Oral History Project
+    Naomi Silfversten, Rnth Silfversten Coppins, Betty Hamspen
+    January 29, 1998
+    Page 4
+    What is your brother's name?
+    Hilden?? And of course she was a twin and the other brother passed away when he was 19
+    months old.
+    Then the family moved to Duluth and that is where all-
+    There was - this church had a parsonage down the block here and - so that. is where we were
+    for a period oftime. I don't remember how long because at that time Dad decided he wanted
+    to build his own home so he got some property up on Central Avenue so - but at that time
+    mother took ill and she was an invalid from the time she was 40 years old until she died in
+    1995. But nevertheless we managed to get along. They sold the parsonage and then we
+    moved down to 53" this way temporarily until our house became livable or we could move
+    in. So that is where we spent most ofour time.
+    What do you remember about your ethnic group?
+    I don't recall what we singled out -we chummed around with anyone and everybody. We
+    had different nationalities. I can't say that we singled out the Swedes or Finns. A great part of
+    our time was spent here at church. When we went to school or out to play it was all
+    nationalities. But I think that we had a normal growing up as anybody else. Except that we
+    were the minister's kids and you felt you had to be so good because your father was a
+    minister.
+    It is a lot different now. Even the ministers are different. It's kind ofnice because - you're
+    something a little special. I don't know ifthey felt that way or not. We lived a normal life.
+    ------:-----Htilro.-.wVlfabhOlrurrtt-allJ1mniiinnmisltt<>err"'s-Ufe in those days?-----------------------
+    Visit sick people, that is part oftheir ministers in the homes or in the hospital and he had to
+    attend a lot of different meetings with other ministers and they had to go out oftown and the
+    conference meetings and things like that. Dad was not interested in sports or anything but he
+    loved to fish so any time that he could get up to Boulder Lake or Fish Lake or sometime I
+    remember being with him a couple oftimes and he was very patient and we just sat all day in
+    the boat.
+    I remember going on part ofhis vacation with him once because he went up to Eagles' Nest
+    Lake and he had fixed the car the back seat - the back part ofthe seat so they would go down
+    and you could sleep in the car and I remember being up there with him for several days with
+    him and I don't remember how old 1 was but I remember-
+    He loved to fish.
+    I remember also one time he fished at Islaud Lake and the blinding snow storm on the first
+    fishing day ofthe season May 15 so here we are in January thinking ofwhat we might have
+    to look forward to.
+    Swedish Immigrant Oral History Project
+    Naomi Silfversten, Ruth Silfversten Coppins, Betty Hamspen
+    January 29, 1998
+    PageS
+    How would you describe a typical week for a miuister?
+    Church, church. Oh well yes and his daughters and son spent all of our time here. We used to
+    have three services on Sunday: a Swedish, and English, and a Swedish at night and we three
+    kids so caIled we all had to take our turns at being the organist -we alI had training - we all
+    had lessons of course piano and organ so brother first because he was older and then I went
+    on to nurses' training and my sister, Ruth. So we alI had to spend lots oftime here and lots of
+    time then we would have prayer meetings on Wednesday we had to be here. Friday was choir
+    practice because then we had to take care ofthe choir and then the three services on Sunday.
+    Ofcourse Saturday was confirmation and for whatever. We had willing workers and I
+    remember we had it in that second room especially when it was real cold and Dad would put
+    fire in that little stove so we huddled around that.
+    Is this the organ?
+    That's the organ -that's the one we played.
+    So you were the center of attention?
+    Well, we didn't have a choice; put it that way.
+    Any stories?
+    I can't remember but like I say it's a little different now with pastors' families. Kids speak up
+    more than - I belong to Pilgrim Lutheran church in Superior and I have been there ever since
+    ---------I've-bllen-marrilld-m1d-so-I've-been-going-as-member~nd_I-knew-the-family-life-is-a-little-bitt-----­different
+    than they were when Naomi and my brother and I grew up here. But that was the
+    times; everything has changed. And one thing I have to say that I am proud to say that I was
+    brought up in the minister's home. I am very happy that that time-
+    Even ifthey were so strict. Mother wasn't but Dad ofcourse -he ruled the roost, I can tell
+    you.
+    Was he a strict miuister?
+    WeIl, it wasn't fire and brimstone, I don't think. He had some good sermons. You know-
+    Was the church a place where somebody was coming from Sweden - did they come to
+    the church in those early days?
+    We did have quite a few people that came over from Finland and find our church. I think it
+    was mostly the men who came and some ofthem went back and some didn't go back to
+    Finland.
+    Swedish Immigrant Oral History Project
+    Naomi Silfversten, Ruth Silfversten Coppins, Betty Hamspen
+    January 29, 1998
+    Page 6
+    Oftenwe had visitors to cometo the church; guess wherethey stayed overnight. We would be
+    routedout ofour cribs or bedsto take care ofsome other ministerthat is comingto visit. But
+    it didn't hurt us.
+    Did you get late night phone calls of death in someone's family?
+    I don't recall muchofthat. Dadhad a studyand -
+    Onething about himthat - he quite oftenhe was up in the middle ofthe night andthen he
+    would go downto the kitchenand cookand drinkhis coffeeand study and write sermonsand
+    of coursehe did write somebookstoo but that is whenhe did his thinking becausehe said it
+    was always more quiet in the houseduringthe nightthan it was duringthe day whenwe were
+    around. Quiet, quietdownthere.
+    Was he a prolific writer?
+    Yes he was. Hehad outlinesbecauseI think I have somestill at home- someoutlinesand ­he
+    wouldpreach fromthem.
+    He wrote a book?
+    Yes I happenedto - I haven't had time to - I have all these and I have to get this all together
+    - the Finland Swedes in America; this is it. It waspublished in 1931 and it is all here
+    translatedto the English languagebut howI received these was through the Swede-Finn
+    Historical Societyand there referredto the Finland Swedes had a lodge and they are still
+    active out west- Bruneberg Lodgeandthe Bruneberg Lodgeof Seattle is then there - they
+    had publications calledthe LeadingStaror in Swedish? but - so the editor of that paper,
+    ---------I\}oug Hansen,we were in touch or contactandhe said that we WIll seethat youget the
+    publication and this is of course I wouldtake it out likethis and so there is 26 chapters. It was
+    a big book;just by lookingat all of this you can see what our fatherwas doingin the middle
+    ofthe night besidewriting for sermons andthis wasn't the only book.
+    Did he ever tell you why?
+    Oh,he was so proud ofhis peopleand he felt it andthen of coursehe traveledto get some
+    . information for the book.He went out west andthere are quitea few Finland Swedes in that
+    area, and California and out in Michigan and Mass. Andalso Australia; there are a lot of
+    Finns and Swedes. Sothis is what I say; he reallydid quitea bit of-
+    He knew of the other people who were working the church; is that where he got the
+    information?
+    Ipresume he got that throughmanypeopleand I think towardthe end here the several people
+    that menthat were influenced him andthat is wherehe got informationfrom.
+    He wrote that in Swedish?
+    Swedish Immigrant Oral History Project
+    Naomi Silfversten, Rnth Silfversten Coppins, Betty Hamspen
+    Jannary 29, 1998
+    Page 7
+    Yes, in Swedish.
+    Was he in the lodge?
+    We - I think we were members for a while. W.e weren't lodge people; we never had been.
+    There wasn't any reason to. It was a sick benefit.
+    Was there a chapter here in Duluth?
+    They had many years ago but they had it - there were two up on the range also.
+    What other books did he write?
+    I have sent a couple ofours out there. Well we know "Safe Channels" aud then "My
+    Home... " and I don't remember the translation ofthe rest of it. I don't have the list with me
+    that I sent to the Historical Society.
+    Did he perform a lot of weddings?
+    I imagine he did at one time; it was a very busy church and congregation. And so he it was a
+    lot ofactivity in this church.
+    How many members?
+    200 or so. Maybe when they were at the peak time might have been.
+    Was this church built when he arrived?
+    Yes, it was. Yes, because there were other ministers here before Dad came. Pastor Oberg was
+    here. Kastlin? was here at that time.
+    You said there were 200 or 300 people and you had church services and choir practices;
+    were there other social things and choir practices?
+    We had dinners and church suppers - oh yes, and we eveb had lutefisk suppers and trout
+    suppers - must say something right at this popoibnt, too,that dad organized a church out in
+    french river - a church oput there - he felt the need - beind Dad was so interested infishing
+    and all he fel the need along the shore out there and then found out they were Finland­Swedes
+    and that there was quite a number ofthem - maybe, it was kind ofa mission church
+    at the time out there so he did organizethat too. They built after a while but the fi5rst so­called
+    services were held in the homes - and then after that they did buid a church up on the
+    Ryan road and that was there until they decided - I'm trying to thiuk ofthe date - 51 or 2­52
+    and then they had ground-breaking for the new church onRyan road that's there now - so
+    it's an active church.
+    Swedish Immigrant Oral History Project
+    Naomi Silfversten, Ruth Silfversten Coppins, Betty Hamspen
+    January 29, 1998
+    Page 8
+    Another pastor?
+    No, he was the pastor there for several years, taking over that so he had this church and then
+    French River. In between when he must have ahd a little time - back ill the '30's - he was a
+    pastor up in Eveleth, at that church, so he spent some ofhis time - I say a third ofhis time­see,
+    he had three churches - and so he was busy.
+    Eveleth in the '30's-
+    Well, I know because I used to accompany him. I used to play that organ there - kind of a
+    reed organ- they had somebody blowing it or pumping it from behind or whatever - so - 1­that
+    was a long trek.
+    Can you imagine some of the dinners-Iutefisk?
+    Oh, that was important part of- in those days - and as I say, lake trout - you see the
+    connection we had was French river - then - I remember going up with dad one morning and
+    waiting for the - Mr. Sundstrom - Mr.Gunderson- they write out -having pulled up their nets
+    and fish and so forth -really fresh fish- I remember getting it and putting it on the back seat
+    and offwe went to betherl- fresh - so we had lake trout suppers. That was very good. Of
+    course I do like lutefisk, so that was - still do! You could have it everyday and twice on
+    Sundays.
+    What about special times like holidays - Christmas, Easter - were those a lot of
+    A lot ofactivity in the church - you know, Sunday school program here, and we all had to
+    take part in that and - special church events - Christmas morning you'd always have morning
+    services at 6 o'clock in the morning.! it was called - surprising how many people came out
+    for that ~ frost on the windows ---candles next to the windows, you know - it was very very
+    ,
+    Did you open presents before or after?
+    Don't say presents - present - we were lucky then. That was a special service - course we
+    had Easter service also. Good Friday - Good Friday services we had in combiuation with
+    other churches - we had Elim, .. and other churches. Isn't that funny, I can't remember too
+    much on that. Don't know. Can't remember ..
+    Confirmation and •••••
+    And then after coufirmation the group that we called our Junior league or Luther League ­pretty
+    active
+    How would you describe the Luther league •••?
+    Have a program and - I don't know ifwe had speakers or anything like that but -I don't
+    recall. It was an active - very active time.
+    Swedish Immigrant Oral History Project
+    Naomi Silfversten, Ruth Silfversten Coppins, Betty Hamspen
+    January 29, 1998
+    Page 9
+    Where you had officers and had a meeting?
+    We might have ha d a president -
+    Dances or parties?
+    Oh, heavens, are you kidding? You must be. We weren't even allowed to go dancing or to a
+    'movie -or- times have changed. It was strict.
+    It must have been difficult for you going to the public school and
+    1 always think back going to prom night -I think it was at the Spaulding - we got dressed up
+    - and nobody asked me to dance because the kids all knew 1was the minister's daughter, so 1
+    was there for a wallflower.
+    Well, you were lucky - I don't think anybody ever asked me to go.
+    Well, 1 mean 1went - a bunch of- you know- As 1 say 1 didn't get to dance.
+    He was pastor here for a long- a relatively long-
+    26 years.
+    Did - from the time you came to the time - did that change quite a bit?
+    Til the time he retired?
+    Were churchpeople more liberal and the Sewdish services?
+    Oh, no, he cut out the Swedish services - Well, 1don't recall too much. You see, 1went in
+    nurses' training in 193 and 1 don't know - 1came back here to Duluth in 37 - but well, yes, 1
+    s'pose 1came back to live at home because 1startedto work - 1 don't remember - isn't it sad
+    - I'm getting aged it's hard to remember - you were home, too
+    Special memories ofthe Depression years in Duluth?
+    They certainly weren't very good but everybody was in the same predicament. Cause, things
+    weren't as costly as they are now so we managed. 1think from what 1 remember - was his
+    salary $125 a month - he when he passed away in 1953 - from '46 on, when he retired, his
+    pension was $35 a month.
+    Who was - when you say he had a boss he reported to?
+    Swedish Immigrant Oral History Project
+    Naomi Silfversten, Ruth Silfversten Coppins, Betty Hamspen
+    January 29, 1998
+    Page 10
+    They were called bishops - or it'd be like the head of the synod - Augustana Synod - and I
+    think it was probably - they had branches - the ministers from this area maybe had to report
+    to someone down in the cities But they main synod was in Rock Island, I think - the
+    Augustana, so - oh, yeh
+    There was a hierarchy?
+    Oh, yes, oh, sure they had to. They had all these obligations and things when the church - the
+    main church now what it is called is Evangelical Lutheran Church in America.
+    Urn, women's role in the church - how would you describe that?
+    Very active I would say.
+    Ladies' aid society?
+    Very active, um-hmm, Dorcas society, they were the mainstay ofthe church, you know, in
+    those days, very active. I think in most churches they are still the mainstay. The groups and
+    the things that they do. It was a very active church. Good choir, and there's a picture on the
+    wall now. Alberta directed the choir. It's so little. He was quite a musician.
+    And you said some ofthe services were in Swedish?
+    Most people could understand Swedish. I could understand Swedish quite a bit. 1did way
+    back. Come to church and hear Dad preach in Swedish, I couldn't quite get it all. At home, if
+    he and my mother wanted to talk about something and they didn't want us to know what they
+    were talking about, they'd speak Swedish and we knew what the were talkin about. We
+    cou trans ate that. It was a little bit different.
+    Speak in Swedish?
+    I suppose most ofthem. He did a lot ofperiodicals too for the church. And then he wrote for
+    the? But... periodicals for the church itselfand so
+    Any other humorous stories?
+    How many people are going to listen? Statute of limitation run out?
+    We can delete some of it. Other things that might shed some light on
+    Oh, other thing he did for a hobby, he built boats. Like rowboats. I don't know. He had
+    special- Weide, and long at the bow Garage and our basement. I don't know how many he
+    had built. How many years - maybe you don't recall the Knudsen Shipyard - ofcourse, it
+    was in Superior- and in fact I know the granddaughter of the Knudsens, and anyway he came
+    one time to look at my dad's boat and he complimented him on it, he said it was a very well
+    Swedish Immigrant Oral History Project
+    Naomi Silfversten, Ruth Silfversten Coppins, Betty Hamspen
+    January 29, 1998
+    Page 11
+    done. So that's what he did as a hobby, in his spare time. After writing and preaching and all
+    these other things. A winder man.
+    Parades and carpentry and wood-working••• Character, do with your families •••
+    I know one thing that I do all these years I always any place that I go, I always go about half
+    an hour before I have to be there because I don't want to be late because I remember dad
+    saying I'd rather be anyplace a half hour early that a haifa minute late. And I carry that
+    tradition. I think people have - I'm a believer in being early. That carried over here with me
+    too ofcourse.
+    Strong work ethic, I s'pose?
+    Well, not _ I can't say that.
+    Your father and n!'w your brother •••
+    Well, I've stayed single and been in the nursing profession most ofmy life except for 20
+    years now I've been retired from it. I kept pretty busy. I spent most ofmy nursing time at the
+    Duluth Clinic. 39 years - surgery section - surgeons, orthopedics, and for 10 years
+    supervisor ofnurses and aides, and so that was very interesting work.
+    You told earlier •••
+    1988.
+    Story behind that.
+    Well, we have this organization or so-called - Finland Swedes; they get together - Margaret
+    Orley started this many years ago- might be over 10 now - she passed away last year - and
+    she said something about - she asked at one ofthe luncheons ifany ofus would be interested
+    in taking a trip tpo Finland, so I was interested. Because 1didn't know of any relatives at that
+    time - maybe this was a good time to look up somebody ifwe get up to the Verkas area so
+    she organized this tour and I think there were 22 ofus but we weren't all from Duluth. That
+    went ofthis trip - we spent - 2 liz days in Verkas, that's all but while the planning was going
+    on had been over in Finland and found a Harry Silfversten that lived in Memphis, and we
+    corresponded and so then there was a reason and I was invited to stay with them which I did
+    and so we got to see the church where Dad grew up - it was built in 1453 - a beautiful church
+    and he had been back in 1927 and preached there so I was - I took some pictures ofthe pulpit
+    because it was up pretty high and those churches they are and then take in a couple of
+    cemeteries and found some more Sifverstens - only they were below ground at that point, and
+    it was a funny feeling to be way over in Finland and then you see these tombstones - the
+    fellow named - same as ours - of. Course it was correct - in past years trying to find more
+    Silfversten's -this Harry Silfversten - did start a genealogy- ofSilfversten - and I was able
+    to fill in a few things about our family and then I have - its in booklet form, cheaper than this,
+    and find out there are several Silfverstens in this country bot they've changed their name to
+    Swedish Immigrant Oral History Project
+    Naomi Silfversten, Ruth Silfversten Coppins, Betty Hamspen
+    January 29, 1998
+    Page 12
+    Silverstone so - you can't - at this point in my life. I'm too old now to go through some more
+    history - I've done enough. But why - it all comes at this time in my life - these things - and
+    yet a ways back, we wouldn't have been interested- we weren't. Now how important is-
+    When you're reading these stories of your father's translated, are you making
+    discoveries ••
+    I have to admit that I haven't looked through them yet.. I shouldn't say I have no time, but I
+    have to start one of these days and start fromthe beginning, but just from what I have read,
+    some portions -I'm amazed at what he did, in writing. I can't believe this was all published in
+    1931- my goodness. And all the facts, my goodness, he really delved into this history of the
+    Finland-Swedes here in America. I was kind of hoping Mr. Fortnerwas here; I was goingto
+    ask him how to ? about - I'd like to have this edited but not for anybody's information,just
+    for my sister and me becausethis can be destroyed- it's worth something I meanto me, I
+    guess.
+    Bethany home?
+    The children's home. Its called North Woods - Bethany crises center it is on 40th
+    avenue west just right above the railroad tracks. It was on 40th I remember and not the
+    - the big building'was on 40th but the other one was down on the avenue because I
+    remember going over there sometimes. It was a big house - on the comer from the
+    supermarket. That was the first then they built and went across the railroad tracks and
+    that big building is still there - it is called Northwoods Crises Center.
+    Did your dad have any connection?
+    I suppose I think he went there and may have had a speaker and spoke one time or
+    other but it was a place for orphans and I don't know ifthey had any programs. Ijust
+    remember going there once but I can't remember what ifwe had a bunch of church
+    here to go or - that is a long, long time ago.
+    By the way this coming year 1988 or 1989 its going to be 100 years old - this is 1998
+    I know but it would be a 100 years old or 99 years old - because I asked Mr. ? that
+    last year because he mentioned about removing the corner stone when the church was
+    100 years old and so forth so I think. either this year or -
+    What year did your father retire?
+    1946.
+    He turned it over to another pastor?
+    Swedish Immigrant Oral History Project
+    Naomi Silfversten, Ruth Silfversten Coppins, Betty Hamspen
+    January 29, 1998
+    Page 13
+    Oh yes and from then there were several pastors. Two or three. Matson was the last
+    and who was the other one? Falk after dad.
+    I don't remember when the church - Mr. Fortner. had this church for about 10 years
+    and it was empty for a while before Mr. F bought it.
+    Did you dad continue to write after he retired?
+    Oh yes he continued to write, fishing, fishing.
+    He painted several altar paintings for various churches. He painted French River
+    Lutheran and there is one now that is Holy Cross and that's a big one that is in the
+    Fireside room. There is one in Fellowship Hall in French River. I understand that
+    there are others in Concordia when we belonged to that little white church. He
+    painted that alter painting and I think somebody mentioned the Arnold Church which
+    is now the Family ofGod church there should be something there. I haven't pursued
+    'all ofthese leads. We do know that he was wonderful artist. And music and whatever
+    he was - practically everything. A farmer. And a newspaper - he wrote and was
+    editor ofthe Mound Sun Newspaper. He composed music, opera. Now this is our
+    brother not our father.
+    Anything else?
+    He used to love children and in our home there on Central Avenue, his study of
+    course was offthe living room and the windows on the study face the porch because
+    that was years ago when they all had process and the little kids in the neighborhood
+    End of tape
+  transl: {}
+  fullrs: {}
+  find: 1194.pdf
+  dmaccess: {}
+  dmimage: {}
+  dmcreated: '2021-02-26'
+  dmmodified: '2021-02-26'
+  dmoclcno: {}
+  dmrecord: '1193'
+  restrictionCode: '1'
+  cdmfilesize: '390227'
+  cdmfilesizeformatted: 0.37 MB
+  cdmprintpdf: '0'
+  cdmhasocr: '0'
+  cdmisnewspaper: '0'
+  page: []
+  id: p16022coll548/1193
+id: p16022coll548/1194

--- a/spec/fixtures/contentdm/audio_playlist.yml
+++ b/spec/fixtures/contentdm/audio_playlist.yml
@@ -1,0 +1,415 @@
+---
+title: Interview with John Choi
+photog: Choi, John
+contri: Oh, Insung
+descri: 'John Choi was born in Seoul, South Korea but immigrated to St. Paul, Minnesota
+  with his parents at the age of 3. He received his bachelor''s degree from Marquette
+  University and his law degree from Hamline University. John was the Saint Paul City
+  Attorney from 2006-2010, and is currently the Ramsey County Attorney. SUBJECTS DISCUSSED:
+  Early life - family - the importance of education to Korean immigrant families -
+  embracing American culture as a child - college - practicing law - becoming socially
+  and politically active - becoming St. Paul Attorney and his achievements at the
+  job - getting more Koreans active in society and politics - campaign for Ramsey
+  County Attorney - similarities between all immigrants to the United States.'
+dat: '2011-01-17'
+publia: {}
+dimens: {}
+genera: Immigration and Ethnicity
+type: Sound Recording-Nonmusical;
+physic: Oral histories;
+specif: Ethnicity; Oral history;
+subjec: Korean Americans -- Minnesota.
+city: {}
+county: {}
+state: Minnesota
+countr: United States
+geogra: {}
+geonam: {}
+langua: English
+par: Khmer Oral History Project; OH91
+contra: Minnesota Historical Society
+contac: Minnesota Historical Society, 345 Kellogg Boulevard West, St. Paul, MN 51102-1906
+  http://www.mnhs.org
+righta: http://www.mnhs.org/copyright
+rightc: {}
+rights: {}
+rightd: {}
+public: {}
+identi: AV2011_24_1_M
+resour: {}
+audio: 1_m9tvjl6o; 1_vpgan6fg; 1_zz7vf4az
+audioa: 1_bvlzc447
+video: {}
+projec: Minnesota Digital Library 2013-2015
+fiscal: Minnesota Immigrants is made possible through the generous funding of the
+  Digital Public Library of America Digital Hubs Pilot, which is supported by the
+  Digital Public Library of America with funding provided by the National Endowment
+  for the Humanities and the John S. and James L. Knight Foundation.
+publis: {}
+date: {}
+format: {}
+digspe: {}
+digspa: {}
+digspb: {}
+digspc: {}
+digspd: {}
+digspf: {}
+digspg: {}
+digsph: {}
+digspi: {}
+digspj: {}
+digspk: {}
+transc: {}
+transl: {}
+fullrs: {}
+find: 1014.cpd
+dmaccess: {}
+dmimage: {}
+dmcreated: '2021-07-01'
+dmmodified: '2021-07-01'
+dmoclcno: {}
+dmrecord: '1013'
+restrictionCode: '1'
+cdmfilesize: '326'
+cdmfilesizeformatted: 0.00 MB
+cdmprintpdf: '0'
+cdmhasocr: '0'
+cdmisnewspaper: '0'
+page:
+- pagetitle: Audio
+  pagefile: 1356.mp3
+  pageptr: '1355'
+  title: Audio
+  photog: {}
+  contri: {}
+  descri: {}
+  dat: {}
+  publia: {}
+  dimens: {}
+  genera: {}
+  type: {}
+  physic: {}
+  specif: {}
+  subjec: {}
+  city: {}
+  county: {}
+  state: {}
+  countr: {}
+  geogra: {}
+  geonam: {}
+  langua: {}
+  par: {}
+  contra: {}
+  contac: {}
+  righta: {}
+  rightc: {}
+  rights: {}
+  rightd: {}
+  public: {}
+  identi: {}
+  resour: {}
+  audio: {}
+  audioa: {}
+  video: {}
+  projec: {}
+  fiscal: {}
+  publis: {}
+  date: {}
+  format: {}
+  digspe: {}
+  digspa: {}
+  digspb: {}
+  digspc: {}
+  digspd: {}
+  digspf: {}
+  digspg: {}
+  digsph: {}
+  digspi: {}
+  digspj: {}
+  digspk: {}
+  transc: {}
+  transl: {}
+  fullrs: {}
+  find: 1356.mp3
+  dmaccess: {}
+  dmimage: {}
+  dmcreated: '2021-07-01'
+  dmmodified: '2021-07-01'
+  dmoclcno: {}
+  dmrecord: '1355'
+  restrictionCode: '1'
+  cdmfilesize: '22271'
+  cdmfilesizeformatted: 0.02 MB
+  cdmprintpdf: '0'
+  cdmhasocr: '0'
+  cdmisnewspaper: '0'
+  page: []
+  id: p16022coll548/1355
+- pagetitle: Transcript
+  pagefile: 1013.pdf
+  pageptr: '1012'
+  title: Transcript
+  photog: {}
+  contri: {}
+  descri: {}
+  dat: {}
+  publia: {}
+  dimens: {}
+  genera: {}
+  type: {}
+  physic: {}
+  specif: {}
+  subjec: {}
+  city: {}
+  county: {}
+  state: {}
+  countr: {}
+  geogra: {}
+  geonam: {}
+  langua: {}
+  par: {}
+  contra: {}
+  contac: {}
+  righta: {}
+  rightc: {}
+  rights: {}
+  rightd: {}
+  public: {}
+  identi: {}
+  resour: {}
+  audio: {}
+  audioa: {}
+  video: {}
+  projec: {}
+  fiscal: {}
+  publis: {}
+  date: {}
+  format: {}
+  digspe: {}
+  digspa: {}
+  digspb: {}
+  digspc: {}
+  digspd: {}
+  digspf: {}
+  digspg: {}
+  digsph: {}
+  digspi: {}
+  digspj: {}
+  digspk: {}
+  transc: |
+    20
+    John Choi
+    Narrator
+    Insung Oh
+    Interviewer
+    January 17, 2011
+    Brooklyn Center, MN
+    John Choi - JC
+    Insung Oh – IO
+    IO: This is Insung Oh interviewing John Choi at the Korean Association of Minnesota. Today is January 17, 2011.
+    Could you, please, state your name?
+    JC: Sure. My name is John Choi, last name C-h-o-i, Ramsey Count attorney.
+    IO: Could you spell, please, your name?
+    JC: J-o-h-n, Choi, C-h-o-i.
+    IO: Your age?
+    JC: Forty years of age, born on June 2, 1970.
+    IO: Where were you born?
+    JC: In Seoul, South Korea.
+    IO: Can you tell in detail about your family members, name and relationship?
+    JC: I’m married and I have a wife. Her name is Youn, Y-o-u-n Choi. Then, I have a young son who is two and a half years of age. His name is Will, W-i-l-l. Then, my father and mother. Peter Choi or [sounds like Chay-Chung-Guan] is my father and my mom is [sounds like Ming Yung Good]. Then, Barbara Choi is her Christian name. Then I have a sister Ann Choi and a brother-in-law Eric, last name Roloff, R-o-l-o-f-f.
+    IO: When did you come to Minnesota and what did drive your parents away from Korea to here in Minnesota?
+    Korean Community Oral History Project
+    Minnesota Historical Society
+    21
+    JC: We immigrated to this country when I was three years of age. That was 1973. My father came here to study, get a graduate degree, a Ph.D. He did not end up finishing the degree, but we ended up staying, because, at that time, Korea was not the most stable country in many things. So we ended up staying. My parents were seeking kind of the American dream.
+    IO: Betterment of your family...
+    [break in the interview]
+    JC: Where did your family live at the very beginning of immigration?
+    IO: Yes.
+    JC: Okay. Our first home in America was at Skyline Towers, 1247 Saint Anthony [Avenue. Saint Paul, Minnesota]. Back then, it used to be called the Saint Anthony Apartments. Now, it’s known as the Skyline Towers. It’s very well known. It’s kind of a low income place. That was our first home. Then, we lived in the student housing at the University of Minnesota, also at Sibley Manor, which is an apartment building along West Seventh Street in Saint Paul. Then, we moved out to Eagan and we lived there for a long time. Then, we moved to Inver Grove Heights. I went to college in Milwaukee, Wisconsin. Then, I came back to Saint Paul for law school.
+    IO: In 2009, you kicked off for campaigning for, then, county attorney, at the same place it is now.
+    JC: Yes, Sky, it’s a very symbolic place I think for our family history coming here. For me, I think Skyline Towers represents, today, exactly what it we were experiencing and wanting as an immigrant family back in 1973. Today, Skyline Towers consists of many immigrant families from Africa who are living there. So there are many young boys and girls who are just like me, whose parents came here seeking something different and better in this new country and, then, struggling with all of the challenges of being new to the country. That’s one of the reasons why I chose to announce my candidacy at Skyline Towers, to tell my kind of immigration story, but, also, to speak to many of the families who are immigrants, to show that really anything in this country is possible.
+    IO: You talked a little bit about your parents here settlement after they came over here. How was their living? How was their life?
+    JC: I think we were a very typical Korean American family. When my father was studying at graduate school, my mom was working during that time. She got a job, probably in 1974 or 1975, at Sperry Univac, which was right by West Seventh Street and Shepherd Road in Saint Paul. So she was working there while my dad was going to school. It’s a story really about hard work. Then, my dad ended up not finishing his graduate degree, but then ended up working here at Coca-Cola and then, also, being the reporter for the Korea Central Daily newspaper. So, just growing up very typical like
+    Korean Community Oral History Project
+    Minnesota Historical Society
+    22
+    many immigrant families. One thing that I know that’s very difficult for all families that come from another country that don’t speak English, the language barrier is very difficult. Then, there’s a lot of different cultural things that are different. It’s never an easy thing to be an immigrant family.
+    IO: Like many Korean American immigrants, they are really anxious to teach their children at the best place, like America.
+    JC: Oh, sure. My parents were very, I think, similar to many Korean immigrants that I see. They stressed that education was really important. Doing well in school was probably the most important priority that my parents had for myself and for my sister. I see that as very typical amongst many Korean immigrants and, sometimes, maybe even too much the way they’re stressing the school, putting the pressure on to do well in school. [chuckles] That’s very typical. I think Korean immigrants have defined success that you do well in school. You go to college and go to a very good college and, then, do well in college, and, then, good things will happen if you can get a college degree. I think that’s very true. That’s a very good recipe for any immigrant group coming here to focus on making sure that your children receive not only a high school education but a college education. That was kind of the recipe that many Korean immigrants have fulfilled over the many, many decades.
+    IO: Is that unlike the other immigrants parents? I think, as an undercurrent for their children probably greatly education affected your parents’ priority?
+    JC: I think many immigrant cultures stress the education, but the Korean immigrants, I think, really, really stress that. They make it a top, top priority.
+    IO: How does that compared to other immigrant groups?
+    JC: I don’t know if I can make that comparison. All I know is the Korean experience, and I know it’s very much stressing on the educational achievement.
+    IO: Where did you go for elementary school? How was your early life?
+    JC: My first schooling was at Homecroft Elementary School, which is in Saint Paul, kind of in the Highland Park Area, when we lived at the Sibley Manor Apartments. Interestingly, Sibley Manor Apartments, too, just like the Skyline Towers, is comprised, today, of many, many African immigrant families that live there, as well. When we lived there, Homecroft was the first school. Interestingly, my son, William, he goes to Homecroft right now for preschool.
+    IO: [chuckles]
+    JC: In Saint Paul, they call it Early Childhood Family Education, ECFE. So, today, he goes to Homecroft, which is kind of really interesting. My first school was in Saint Paul
+    Korean Community Oral History Project
+    Minnesota Historical Society
+    23
+    at Homecroft, and, now, my son, William, goes there for ECFE classes with my wife, Youn. So that was my first school.
+    Then, we moved to Eagan. My parents saved enough money to buy their first house. We grew up in a part of Eagan, which is what I would call the working class part of Eagan. It’s down by Cedarvale, which is along Highway 13 and Yankee Doodle Road. It’s kind of considered to be like old Eagan where the first kind of development occurred in Eagan. Most of my childhood, I’d say from first grade all the way until about tenth grade, was growing up in Eagan. That neighborhood [was] very predominantly white. In fact, in terms of minority kids growing up in that area, we were kind of the lone Asian family. Maybe there was two Asian families in the immediate neighborhood, and, then, one African American. Otherwise, everybody was white, kind of a middle class type neighborhood. So my first school was Rahn Elementary, R-a-h-n. It still exists today. I went there from first grade up until sixth grade. Then, I graduated and went to Saint Thomas Academy Middle School from seventh to eighth grade. Then, I went to Saint Thomas Academy High School from ninth until twelfth grade. Saint Thomas Academy is located in Mendota Heights, kind of close to where I grew up. When I went to Saint Thomas I think my parents wanted me to get a Catholic school education and, also, probably thought I needed a little bit more discipline. [chuckles] So it was a good school for that.
+    IO: Do you have any interesting story?
+    JC: Of growing up?
+    IO: Yes.
+    JC: Well, I think growing up as a Korean immigrant family, even for kids growing up, your parents come from a different culture, but, then, growing up, you go to school in American culture. So all the time as you grow up, this is very typical for, I think, all immigrant families. I see a lot of that playing out with the Hmong community and all of that stuff. Because you grow up kind of Korean but more American, growing up in society, but your parents are more Korean, it’s always a challenge to deal with all of those various issues. Then, just growing up in the 1970s and 1980s, at that time, I think our society has come a really long ways in terms of accepting other cultures. Today, I think, it’s much more welcoming in the schools, much more welcoming. In fact, there are some people who seek out diversity. They want their kids to go to a school that has other types of cultures and races. Back then, in the 1970s, early 1980s, no one really talked about that or it wasn’t something that was encouraged. I think our society has come a long way. Just growing up, it was never an easy thing. I think awareness that you’re also Korean probably didn’t happen for me so much until much later in life. I would say not even until after the age of eighteen. Growing up, when you look around and you see everybody who is not Korean, right, and not Asian, I think it’s very difficult to have the Korean identity even as a Korean immigrant. I just viewed myself as just like everybody else, but everybody else was not Korean. Those are things growing up in Eagan, Minnesota, where that’s kind of what the neighborhood looked like and all of that. Korean Community Oral History Project
+    Minnesota Historical Society
+    24
+    IO: What was your dream at an early age in Minnesota?
+    JC: When I was a young boy, I liked to play sports a lot. I loved to play hockey and baseball. As a young child, probably my dreams were to be a professional athlete. [laughter] Then, you realize you’re not as good, so that’s not going to work out. Those were just kind of the early dreams. I don’t think I ever had a dream of being a lawyer or anything along those lines.
+    IO: How was your father’s, parents’ dream?
+    JC: I think just typically like many, many other Korean immigrant families, they probably would have loved it if I would have become a doctor or some professional, like a lawyer, all of that. That’s kind of very typical where they’re pushing you most importantly to get good grades, to go to college, and, then, do something professional after that.
+    IO: Was there any conflict?
+    JC: Like many families, growing up, it’s never easy, especially when you have differences of culture like that, but nothing very typical of Korean immigrant families. That’s the thing when you grow up in this country, in America, there’s ways to think and the American culture is very different from Korean culture. Korean culture is so different. [laughter]
+    IO: Very demanding.
+    JC: Very demanding things, yes.
+    IO: We can do everything.
+    JC: That’s very true. Yes.
+    IO: So tough for the mentality and the physically. They can actually accomplish all of their dreams.
+    JC: Yes. [chuckles]
+    IO: Is there any special, even if you talk about a little bit cultural duality, cultural barrier, or language barrier? You don’t have any special language barrier, probably. My son also came over here at the age of three.
+    JC: Oh, same situation.
+    IO: At the age of four, he started to learn English while he increasingly forgot the Korean language. Korean Community Oral History Project
+    Minnesota Historical Society
+    25
+    JC: [laughter] Yes. I can’t read Korean. I can understand Korean a little bit, and I can speak a little bit, but not that well, only because we came here when I was three years of age. I think just like many other Korean kids growing up here, they speak a combination of Korean and English when they’re communicating with their parents. That was really the only type of Korean that I would speak, so that I could speak with my mom and dad. Otherwise, just growing up in American society, you don’t use Korean, so you lose that and you forget that. Then, maybe, you have a wanting or a need to wish you could speak it later in life better. I can’t read Korean but I can understand a little bit but not a complicated conversation.
+    IO: At an early age, generally, Korean immigrant parents are teaching their children Korean. Sometimes many years after because of their job and their life’s so busy probably in your memory parents have tried to teach you…
+    JC: Oh, yes, my parents made me go to Korean school on Saturday mornings, but I didn’t really enjoy it. [laughter] We ended up I think I was able to not go because I didn’t want to go to Korean school.
+    IO: Can you tell me about something bad happens, like you’re an Asian, you’re a Korean? How were your school years? Did you have any special experience?
+    JC: I always remember that as a part of growing up. I think when you are a different culture growing up in any culture, there’s always going to be that. I remember that going back all the way since schooling started in kindergarten or first grade or second grade, so all of that. There’s always somebody that will call you names because you’re Asian. A lot of times, they don’t even know the difference between Korean or Filipino or Japanese or Chinese. Especially, I think, in the neighborhood where we grew up in Eagan, many of the families that lived there and the kids that lived there, they didn’t really have exposure to other cultures. I think a lot of that was just based upon ignorance. I got through that just like everybody else does. When you grow up, there’s always somebody on the playground or somebody who calls you names or whatever it might be based upon how you look or what your culture is. I’m sure that, even today, that exists for some people, but I think times have changed, too. I see that’s there’s probably less and less of that. Yes, all of that existed all the way through, you know, until, probably, college. Part of that is just kids being kids. Their family experience and all of that wasn’t broad-based. That’s just what I had to deal with growing up, but I came out okay.
+    IO: When did you first realize(you were a Korean or an Asian)? You talked a little bit about it at the age of eighteen or something when you went to college, you met many Koreans. When did you first feel that you were a Korean or an Asian as a minority?
+    JC: I think when you get older. I can’t really pin point it, but I just know it was sometime after eighteen. I think when you become an adult, you start to reflect more on a whole bunch of life issues, one of which is your identity. You reflect on your parents. You reflect on who you are. Then, you start realizing that who you are is not just
+    Korean Community Oral History Project
+    Minnesota Historical Society
+    26
+    American, but there’s also a heritage there about being Korean American and all those things. I can’t think of any specific moment or point, but you just have more of an understanding and awareness. I remember all of that probably occurred in college or after college.
+    IO: I want to hear about your college life. College is very important.
+    JC: Yes, it is.
+    IO: For someone’s future dream or future job.
+    JC: College was a good experience for me. I went to Marquette University in Milwaukee, Wisconsin. Marquette is a Catholic school. It’s a large school; it’s about, maybe, 10,000, 12,000 students. It’s a large, private type of school. It’s located in a very challenging neighborhood. It’s in the downtown area of Milwaukee. Surrounding Marquette is a lot of poverty.
+    I got really involved in college. I decided to start an organization focused on helping kids through a tutoring program, kids that were at risk at school who weren’t doing well with their reading. So I organized about two hundred students to do tutoring and mentoring for kids who were at this middle school. A lot of these kids were not doing well in school, and it was kind of a tough neighborhood. So I organized that, and it was my first experience, I think, of kind of focusing on doing something like public service and doing something for other people, and doing community leadership. That was a really good experience. I learned a lot and I also recognized in myself that I really like to do that, help other people and to think about the bigger perspective of how do we make our community and society better.
+    IO: I became aware of that. One of Saint Paul’s former mayors, I remember, in 2009: I helped a Korean broadcasting videotape as its documentary program about Medtronic’s business story. At that time, the mayor, I talked a lot with him. He[the former major] has got an artificial heart. He was talking about the national poverty in the 1980s, probably Minnesota also in 1980, across America probably, the policy issues of poverty. But, still, that issue keeps coming up. Probably your college life in addition to your scholarly work….
+    JC: The organization was called Students Enhancing Education. The acronyms were SEE. Because of that, I received a number of leadership awards for the college. There was a number of them, but I can’t even remember what they were. Yes,
+    IO: After college at Marquette University, you transferred to Hamline [University, Saint Paul]. Why did you choose that area, change into law?
+    JC: I graduated from Marquette University, undergraduate, with a psychology degree. Then, I went to my first year of law school at Marquette University. I was there for a year, but I knew that after I had spent a year at Marquette—that was five years total—I
+    Korean Community Oral History Project
+    Minnesota Historical Society
+    27
+    wanted to come back home. I got very interested in politics and things like that. I wanted to get involved in the mayor’s campaign. I finished my first year of law school at Marquette and, then, I transferred to Hamline. In between, in the summertime, I got a job on a campaign, a mayor’s campaign in Saint Paul.
+    IO: What was the name?
+    JC: Bob Long, L-o-n-g. That was 1993. The candidates for mayor at that time were Norm Coleman, and Andy Dawkins, and Bob Long, and there was a Marcia Abner, and John Mannillo. Many people ran that year. Norm Coleman ended up winning.
+    IO: Oh.
+    JC: Yes, in 1993. But I worked on Bob Long’s campaign in 1993. That was my first campaign that I got involved with.
+    One year later, Bob Long, ran for Ramsey County attorney and so did Chris Coleman, the mayor of Saint Paul today. So Bob Long, Chris Coleman, a guy named Tom Fable, and then Susan Gaertner, those were the four people that ran for county attorney. Susan Gaertner won. Then, she’s been there for sixteen years. But back in 1994, I worked on the county attorney campaign for Bob Long.
+    IO: That’s interesting.
+    JC: Yes.
+    IO: Related to what you do today.
+    JC: If someone told me back in 1994, ―One day, you will be the county attorney,‖ I wouldn’t have believed them.
+    IO: Still you have many years left to become a lawyer, finish Hamline Law School.
+    JC: I graduated in 1995.
+    IO: After that, what was your professional job?
+    JC: After that, I started at a law firm called Hessian, McKasy, & Soderberg. It was in the IDS Center [in Minneapolis] on the forty-seventh floor. I worked there, too, while I was in law school. I worked there from like November 1994 when I started. I worked as a law clerk all the way through law school. Then, I started there as an attorney after I graduated from law school in 1995. I stayed there till about 1998. There, I was doing a lot of kind of commercial litigation work. I also started developing a practice around government relations and government affairs.
+    [break in the interview] Korean Community Oral History Project
+    Minnesota Historical Society
+    28
+    JC: 1995, I also graduated as a fellow from the University of Minnesota Humphrey School. I was a Humphrey Fellow for 1995. That was a really good experience, too.
+    IO: Why did you choose that?
+    JC: I was very interested in public policy and that fellowship is for people who are interested in public policy or interested in doing something like that maybe later in life. While I was in law school, I applied and I got in as a fellow. A lot of that was because of some of the work that I did back in Milwaukee for Students Enhancing Education. I think that was one of the reasons I was chosen.
+    IO: [unclear]
+    JC: Yes. So I did that.
+    Then, in 1995, I started at the Hessian, McKasy, & Soderberg law firm. Then, I moved in 1998 to the Kennedy & Graven law firm [in Minneapolis]. I made partner at the law firm at a pretty young age. I was only thirty years of age, which is very young to be a partner. That would have been January 2001, I believe, is when I made partner there. I did a lot of work around representing cities and local units of government up at the Legislature and all of that kind of stuff. I was just kind of in private practice representing many, many different clients doing different types of legal work, the government relations also, some litigation and municipal type of law, until 2005. I had a very successful private practice doing many different things. I was honored by being ―Super Lawyer‖ by [Minnesota] Law and Politics and all of those things. But, you know, those are just things where I had a very successful private practice.
+    Then, I got a call out of the blue from Mayor [Chris] Coleman in 2005, after he became mayor.
+    IO: Before you became the city director of lawyers, probably before that you as a professional lived a general life. I think that[the city director of lawyers]’s a turning point for your life. Can you tell me about your starting and finishing of that period?
+    JC: During the 1990s after law school, I was always active in politics, doing community type volunteering work, and all of that. Then, I talk a lot about how I got a call in 2005 from the mayor of Saint Paul, Chris Coleman. I had met Chris through all of that active engagement with political stuff. Nineteen ninety-four is probably when I first met him when he was running for county attorney. Then, I got to know him more when he ran for city council in 1997. Then, he won in 1997, and, then, of course, he decided to run for mayor in 2005. It was interesting that I never really expected that he would call me to be city attorney, because I had actually supported his opponent, Rafael Ortega, for the DFL [Democratic Farmer Labor Party] endorsing convention. But, you know, Chris Coleman and I have known each other for a long time, and we maintained a friendship. I think Chris understood why I didn’t support him, because, at that time, when I was in private
+    Korean Community Oral History Project
+    Minnesota Historical Society
+    29
+    practice, my largest client was something called the Ramsey County Regional Rail Authority. They’re the ones that do the light rail construction and all those things, and Commissioner Ortega was the chairman of the Rail Authority. So when he told me he was running for mayor and asked me to support him, I said, ―Of course, I would.‖ So Chris, I think understood why I would not support him. It wasn’t any reflection on him. In fact, it says a lot about him that he would appoint me as his city attorney. So he called and I accepted.
+    I accepted because I knew that, really, if I didn’t take this opportunity that I was being offered by Mayor Coleman, I would never, ever have some opportunity like this again. At that time in my career, I was thirty-five years of age. I was a young partner. I was making a good salary, and I know if I stayed doing what I was doing, my salary would continue to increase, and, then, it would become even a larger pay differential between what I would be making and what you get paid to be the city attorney. I knew whether it was city attorney or to run for the Legislature or to do anything in politics or public service, if I didn’t take that opportunity to do that type of public service, I would never have that opportunity again or it would not make sense. Do you see what I’m saying? At that time in 2005, I was just very newly married and we didn’t have any children, so really no financial obligations to think about. [chuckles] So I just jumped at that chance, and I knew that this was a great opportunity to do something that I was passionate about, which is to serve the public. Remember the story I told you about Milwaukee when I organized the students for the tutoring program? I really enjoyed always the opportunity to do public type leadership, to try to organize people, and try to do something good. So I took this opportunity. Being a city attorney and doing a good job in that role, very much, I think changed my life to get me focused on trying to continue on in doing public service. That’s why I ran for this position, because of that experience.
+    IO: What were your great accomplishments for four years as a city attorney?
+    JC: When I look back, I think the biggest accomplishment that I had was to get people in the office, not only in the city attorney’s office but, also, even around in the criminal justice system, to maybe think about things differently. I think my tenure as city attorney people will look back on and say that I was able to change a lot of things and focus of the office, one of which is to really champion on some of these kind of lower level crimes, to think about justice and public safety in a different perspective, one of which was to utilize like diversion programs. Instead of sending someone to jail for two or three days for a minor offense, why not try to do something where we get them to stop the behavior, and, then, not do it again? That’s the most important thing. But, sometimes, the traditional approach of we have a consequence for somebody and, then, we send them to jail for two or three days, that doesn’t always work. It might work in the sense that we’re punishing that person, but the criminal justice system is not just about punishment. It’s also about rehabilitation, and I think the most important thing is so that people stop their behavior and, then, don’t do it again. A lot of times, what I see are people that come in the system there might be chemical dependency or mental health issues or they’re very poor. A lot of times, what’s happening is because of the fact that they’re poor; it’s driving some bad life decisions. Then, also, just the background of a lot of people that come into the criminal
+    Korean Community Oral History Project
+    Minnesota Historical Society
+    30
+    justice system, they’re cognitive skills in determining what is right and what is wrong and thinking through consequences that if I do this, I’m going to hurt someone else. If I steal something from somebody, there’s a victim, that I’m stealing from that person. They’re not necessarily thinking like that. They’re thinking I want this today. I want it and I’m going to get it. There’s things that we can do, I think, to try to intervene and get people to get better cognitive skills so that they understand what they’re doing is wrong.
+    IO: Recidivism…
+    JC: Yes, that’s a big thing for me is to try to stop recidivism. I think a lot of days, we don’t spend enough time on that. We spend too much time thinking about what’s easiest and, sometimes, what the easiest thing to do is just to put people in jail.
+    IO: How has your college area, psychology major, affected?
+    JC: I think the psychology major was interesting in the sense that it gives you an experience to look at things from a perspective that there’s things that could be attributing things to behavior in their certain pathology or things that people suffer from. So you understand, I think, that aspect of it all. Sometimes, I think, we are always wanting things to be so logical, but that psychology background gives you an understanding that people suffer from various different things and things of that nature. Yes.
+    IO: Can you tell me about issues like during your professional job, including a city attorney…? I think you are in that diversity in American culture. You probably met a lot of immigration issues. What was your thought? What was the most important immigration issue, if any?
+    JC: Like immigration issues, not so much every day. I think if anything, it’s mostly about my election and the campaign that I ran. Because I ran for office and because I was successful, I run into people all over our community, and many of the people that are just so excited about my election tend to be people who are immigrants themselves or really embrace the concept that America is a country of immigrants. I think people who have that strong belief that America our strength is our immigrant population and they accept that we’re changing as a country, people like that, or people who themselves are immigrants, whether they came from Russia or they came from China, Africa, a lot of people, once they learn about my background, they’re very excited about my being in public office and, then, my running for county attorney. In fact, I think that was one of the neatest things that I experienced as a candidate. I recognized that my candidacy meant so much not only to people who, like me, were immigrants but, also, people who have this very strong belief that this country is a country of immigrants. I think it was very satisfying for many to see somebody who was not born in this country succeed in kind of an electoral way, because that’s, in a lot of ways, a validation of who we are as a community.
+    IO: I think you had a good speech at the last October Korean Service Center, that it’s the most important for Korean American immigrants, that the Korean Service Center has
+    Korean Community Oral History Project
+    Minnesota Historical Society
+    31
+    now became one of the top five across Korean Americans in the United States; that’s the service program for immigrants. I think you got a good speech at that time. What was your speech content?
+    JC: My message was, I think a lot of times, especially Korean American immigrants, we have that model of doing well in school, but, ultimately, a lot of times that leads to seeking a professional career that’s more private focused, whether it’s, maybe, being a lawyer or a doctor or a business person, something along those lines. But, a lot of times, I see a lot of very successful Korean families and their children grow up to be mostly in the private sector. My message there was to encourage more participation amongst Korean immigrants and Asian immigrants, not only in professions that would be more public in nature but, also, just getting involved and participating in civic life. I think as immigrants when you’re a new immigrant, typically, families will be very focused on the survival mode.
+    IO: Yes.
+    JC: They’ll be very focused on just educating their children. But participating civically in the future of our country and to actually take ownership of our country, I really believe that America belongs to all people, all citizens, and the citizens in this country are very diverse. A lot of times, the people that are participating, a lot of times the new immigrants don’t feel that connected. A lot of times, it’s because where they come from maybe politics was corrupt or maybe because someone like them had no say in government. Here, in America, it’s very, very different. You can be anyone. You can be the president of the United States. You can be the governor. Anything is possible politically in this country. In fact, we are a democracy, so it’s about the people. When I think about who, as county attorney, my boss [is], well, that’s the people. [chuckles] I work for the people. People don’t work for me, but I work for the people. That’s a concept of American democracy. What I’d like to see is more and more Asian immigrants become more involved civically in the future and think of themselves that they have a stake in the future of this country. So they should be more involved politically. Whether they’re a Democrat or a Republican, it doesn’t matter that they’re more engaged in participating, that they’re more engaged in volunteering. I don’t see as many Asian Americans as there should be volunteering for just anything, like the American to volunteer for the Red Cross, to give blood, to volunteer as a tutor after school to help kids who are struggling with school. I would like to see more and more Asians become more involved in the future and have a stake in our community.
+    IO: For their own representation.
+    JC: Not only for their own representation, but just for the future of our country. Our country is only as good as people are willing to participate and care for it.
+    IO: Yes. Korean Community Oral History Project
+    Minnesota Historical Society
+    32
+    JC: So my message is that in an American type of democracy, all people really have a responsibility for the greater good to participate. Obviously, people should participate so that the Asian American community is represented, but, also, what I’m suggesting is for the benefit of our country. I’d like to see more Asian Americans, all people, participating actively and caring about American democracy and where we’re going from here, because the future is really up to us as citizens. That’s the beauty of this country.
+    IO: That speech was right before your election.
+    JC: Yes.
+    IO: After the election, you came up into Korean Association’s general conference, general meeting, and also, on January 5th, there was a swearing in. At that time, you were with us speaking about your parents. You said that they didn’t even think about that you could be a county lawyer, that’s a big history, I think, for a Korean American in the U.S. Can you tell me about that?
+    JC: Yes, I think when most immigrant families come to the United States, the concept that I just articulated about the American democracy, that it really belongs to all citizens, those are things that we’re not really thinking about. [laughter] We’re thinking mostly about just surviving, number one. Right? In fact, many immigrants who come here come here as refugees. If you look at the African immigrants, you look at many immigrants like the Hmong, they’re coming here because they’re trying to escape something very horrible, a horrible situation. The Korean immigrant experience is a little bit different here in Minnesota. It’s not so much a refugee type of situation. It’s more seeking a better life. But, still, you’re very focused on the many challenges of living in a new homeland. You don’t speak the language as your primary language. There are many customs and cultural differences that the majority culture has that you don’t know about or that you’re soon learning. Then, the challenges of even trying to educate your own children in a different culture, in a different system, is very, very overwhelming. I think a lot of times, people are so focused on that, the thought that your son or your child would become something in a very important role in government, is I think difficult for all immigrant families to grasp. But, in a lot of ways, the fact that it’s possible in this country that someone like me could become elected as Ramsey County attorney, that’s what makes people feel so good about this country. In fact, I think this is really not possible like, as an example, in Korea. If someone from another Asian country moved to Korea, right, and wanted to become the chief prosecutor, elected prosecutor, could that be possible? Probably not.
+    IO: No, no.
+    JC: But that’s the case for most countries. For some reason, in America and some other countries, like maybe Canada and other places, it is possible. I think that’s the beauty of this country and why my particular election was very captivating for people who have been here for many, many years. It says so much about our country. Korean Community Oral History Project
+    Minnesota Historical Society
+    33
+    IO: Many Korean immigrants, Korean generations, have a shadow of Korean War. In Minnesota, there are many, many Korean War veterans. With them, how did you experience with them?
+    JC: One of the most interesting experiences that I had as a candidate and campaigning for Ramsey County attorney was, actually, an accidental meeting that I had with Korean War veterans. It was the day of the election, and I happened to be just kind of driving around looking for things to do during the Election Day to do some campaigning. I came across a meeting of the Korean War veterans that was happening in Roseville, just by accident. There was a whole room full of people, but it was a very special moment, where during their meeting, I was able to actually speak. One of the wives of the commanders went up and talked to her husband and said, ―You should let him speak.‖ So I was able to do that. It was really nice, because I was able to thank them for their service in Korea and, also, suggest and tell them that I probably wouldn’t be standing right there at that moment in time but for their service in Korea. I think that was a very meaningful statement and observation that meant a lot to a lot of people. Then, I got a chance to talk to them after their meeting. A lot of them actually had voted for me. It was about two o’clock in the afternoon on Election Day. After having some of those conversations where people had said that they had already voted for me, I think I had that pretty solid or very sure feeling that I was going to win around two o’clock in Election Day. Yes.
+    IO: You had a chance of coincidence.
+    JC: Yes.
+    IO: In 2009, you got award from the International Municipal Lawyers Association. What was the award about?
+    JC: This probably goes to your question number twenty or whatever, about the same director of city attorney’s office. I talked a little bit about it in my previous answer, about just kind of changing and reforming the system and making some changes. I was really proud of being recognized actually by all of my city attorney colleagues in the United States and Canada as being the top city attorney in North America in 2009. I got that award [Joseph Mulligan Award] primarily because of the work that I talked about, about trying to find innovative solutions to get people who are coming into the criminal justice system on low level offenses not to come back again, you know that whole issue or recidivism in addressing that. So one of the things that I’m really proud of—you asked me what I’m most proud of—is that type of approach and having success at it.
+    One was that driver diversion program where we’re helping lots of people who are driving without a valid driver’s license. Instead of trying to throw all those individuals in jail, which does us no good, we try to help them get their license back and pay back their fines that they owe to government and, then, get them a license as quickly as possible so that they can drive to work and do those things instead of taking a different perspective. That was a very different way of looking at things. Korean Community Oral History Project
+    Minnesota Historical Society
+    34
+    IO: I think you may talk about more campaigning. During the campaigns, a lot of happenings, staff members hard time campaigning. You appreciate the celebration of election night and your victory. Can you talk a little bit more about campaigning?
+    JC: It’s a long, long campaign. In fact, it probably started back in April of 2009 for an election that was occurring in November 2010. So it was a long, long process. Actually, the campaign started from two of my friends who kind of tried to recruit me to run on Facebook when I was city attorney. So they started up a Facebook site. But it really took off. Within one weekend, it had over hundreds of supporters, and, then, over time, it just continued to grow. That was an interesting experience of just trying to put together a campaign. I was always very overwhelmed by the fact that there were so many people who wanted to help. A lot of those individuals that really wanted to help were people that were very captivated by the fact of what my background was, not just because I was qualified for the position, not because I was a city attorney and the things that I had accomplished, but some of my support was, clearly, because their spirits were kind of uplifted and kind of motivated by the fact that I was an immigrant to this country seeking higher office and that I was someone who was different.
+    There was a lot of people who just because of that got very involved in my campaign and I think that speaks a lot to kind of where we’re at as a society, where that is something that is valued by people. In addition to that, there was a lot of people that got very involved in the campaign, like my parents. My mom and dad spent a lot of time working on the campaign, putting up lawn signs and things like that. I think that was really wonderful to see. Remember, we talked a lot about how immigrants come here and there focused mostly on just surviving and doing what you need to do to raise your family, but you don’t think too much about connecting to the political process or the civic or the community stuff? It was great to see my mom and dad become very involved in the campaign, to put up lawn signs all throughout the county. So it was an incredible amount of work. I, also, saw that in the broader Korean community here in Minnesota and, also, around the country. Here in Minnesota, there were a lot of people in the Korean American community that were very captivated by my campaign, because my personal experience and who I was spoke to them exactly in terms of what their American experience was of coming over here and having all if the various challenges that all immigrants face, but, then, also being Korean. It was great to see so many people help, participate, whether it was through coming to a fund raiser or putting up lawn signs. There were some people who went out and helped campaign and did door knocking and all that kind of stuff. Then, beyond the Minnesota Korean American population, I got a lot of support from Korean Americans nationally. That’s because there have been some Korean Americans who have already run for really, really important offices, like Sam Yoon, who ran for…
+    IO: Boston mayor
+    JC: Yes, the mayor. Korean Community Oral History Project
+    Minnesota Historical Society
+    35
+    IO: From outside of Minnesota. He[Sam Yoon] is the second generation. Is there any encouragement from them?
+    JC: Yes, it was great. Because they had already run for a very high-profile race, they had developed a group of other Korean Americans throughout the country that were very interested in supporting Korean American individuals who were running for important positions. So Sam Yoon, who was a former council member in Boston ran for mayor in Boston, he helped me get connected to a number of those individuals, and we raised a very good amount of money just from people that I had never met before, people that just because I was Korean American and they knew I had a good chance of winning, they wanted to help me get over the top. So that was really nice to see.
+    [someone else speaks – unclear]
+    IO: I think I put that kind of story on my Facebook at that time, after the election, that sixteen people, seventeen people, across America, Korean second generation, got into the public office. What was thinking about…
+    [break in the interview]
+    JC: There are so many other Korean Americans that won their elections. I think that is really great. It says a lot about how far the Korean American community has come in terms of being engaged in our civic and political aspects of our country. It was really great to see that. I think there will be more and more of that happening. In fact, there was one particular candidate [Steve Kim] who didn’t make it, but he was running for attorney general in the State of Illinois, which is a really hard race to run in a statewide election. I think that will happen at some point where we’ll see a Korean American get elected at a much larger level.
+    IO: Yes.
+    You got in your future plan: City attorney is different from county attorney. What is your plan in the future for community?
+    JC: The job that I was elected to do to be county attorney is a really, really important job. It’s not as high profile as some other positions like the Minnesota attorney general or things like that, but it’s a really, really important job. My goal is just to do a really good job in that role, and to make change in the criminal justice system. It takes a long time. It’s hard to get something done in one, two, or three, or even four years. In fact, it takes many years, many terms, I think. I’m going to be really focused on just trying to get the job done and do a lot of the things I talked about during the campaign, to try to address some of the recidivism that we have amongst juvenile crime and try to get kids who are getting into trouble on the right track in life, to focus on domestic violence and do everything that we can to prevent it and to hold the people who break the law accountable for that. The list goes on and on of all the things that I want to accomplish. I think the most important priority for me is just to do a good job. Typically, the person that has
+    Korean Community Oral History Project
+    Minnesota Historical Society
+    36
+    been elected to county attorney, they tend to do it for a long time. So I don’t know what the future will hold for me, but, all I know, is that I’m just kind of committed to doing a good job and, then, whatever happens with future opportunities, they’ll come about because I’ve done a good job in what I’m doing today.
+    IO: I think in our Korean immigration history, your wining of your county attorney election is a lot of significances for your family and you and our Korean community and furthermore, to Asian Americans, you know. Your ceremony on January 5th swearing in, at that place, what were you thinking about. What was your thought?
+    JC: It was just a really neat day. I was actually a little bit surprised by so many people that showed up when I took my oath of office. The whole third floor was packed with people that were supporters of myself and Matt Bostrom [Ramsey County Sheriff]. It was really neat to see that. I’m very aware that that there’s a historic aspect of my swearing in. I know all of those things. But I think what was probably just most on my mind was just the enormous responsibility that I have of being the elected Ramsey County attorney. So my thoughts were probably mostly on getting ready to get down and get to work, start getting to work on those things that I wanted to do. I was kind of relieved when all of the swearing in stuff was all over with, because that’s very ceremonial. Then, I got to focus on the job. [chuckles] What’s most rewarding is just to start thinking about that. That’s why I worked so hard during the campaign was to get the honor and the privilege to be able to do the job and to serve the public.
+    IO: Do you have any last words? You can talk about your parents. What is the significance of speaking as an interviewee to this oral history?
+    JC: Sure. I know with respect to my personal story, I’m glad that I had the opportunity to kind of tell it a little bit and I hope, in a lot of ways, I really believe that my story, even though part of my story is about being elected as Ramsey County attorney, in a lot of ways, though, my story really is just like anybody else’s story of kind of that immigrant experience. I think there’s a lot of commonality amongst immigrants who come from anywhere whether it’s Russia, or Africa, or wherever it might be. There are differences, lots of differences, but there are also many, many commonalities. What I predict in the next ten, twenty, hundred years is that there will be people just like me, somebody who was born in Africa or someone born somewhere else who will be elected to high positions in the State of Minnesota and not just here in the state but across the country. We’ll one day look back upon the wave of immigrants; I came here to this country in 1973. During that time period, there were many, many Asian immigrants that have come to this country. Then, we saw in Minnesota a high influx of Southeast Asians, Hmong immigrants coming to this country. I really think a hundred years from now, people will be looking back on that and thinking of it as just a part of our history and nothing more or nothing less. Today, when we look back on Minnesota history, we think of the Irish immigrants. We think of the German immigrants. We think of the French immigrants like in Frog Town [Saint Paul neighborhood] and all of those things. Well, there will be very similar types of stories and neighborhoods that will exist in Saint Paul based upon kind of our immigrant story and will look very, very different, I think, in the future as well. Korean Community Oral History Project
+    Minnesota Historical Society
+  transl: {}
+  fullrs: {}
+  find: 1013.pdf
+  dmaccess: {}
+  dmimage: {}
+  dmcreated: '2021-07-01'
+  dmmodified: '2021-07-01'
+  dmoclcno: {}
+  dmrecord: '1012'
+  restrictionCode: '1'
+  cdmfilesize: '618770'
+  cdmfilesizeformatted: 0.59 MB
+  cdmprintpdf: '0'
+  cdmhasocr: '0'
+  cdmisnewspaper: '0'
+  page: []
+  id: p16022coll548/1012
+id: p16022coll548/1013

--- a/spec/fixtures/contentdm/image_with_transc.yml
+++ b/spec/fixtures/contentdm/image_with_transc.yml
@@ -1,0 +1,110 @@
+---
+title: St. Cloud Hospital School of Nursing graduates 1950 - 1951, St. Cloud, Minnesota
+photog: Kray, Lidwina; Town, Marian; St. Cloud Hospital School of Nursing Alumnae
+  Association
+contri: {}
+descri: This board includes individual portraits of students from St. Cloud Hospital
+  School of Nursing, Class of 1950 and Class of 1951. The photographs are black-and-white
+  prints mounted on two cream colored paper boards, with identifications hand lettered
+  in black ink. They are mounted on a large, brown paper board. The first training
+  school for nurses in St. Cloud, Minnesota, opened at St. Raphael's Hospital (predecessor
+  to St. Cloud Hospital) in September 1908, one year after the state legislature mandated
+  that all nurses working in Minnesota hospitals be licensed. As did the hospital,
+  the education program operated under the auspices of the Sisters of the Order of
+  Saint Benedict in St. Joseph, Minnesota. From its inception until it closed in 1987,
+  the school was conducted as a three-year diploma program that blended academic and
+  practical training for the nursing profession. In 1964, the school began admitting
+  male and married students. The large format photo composite boards were first created
+  in 1958 by two graduates of the school, Lidwina Kray and Marian Town, as part of
+  the St. Cloud Hospital School of Nursing Alumnae Association celebration of the
+  school's 50th anniversary. The boards were displayed in a book-like frame that allowed
+  viewers to page through the history of the school's students.  Each year following,
+  graduating classes added their portraits to the 'book.' There are 50 boards in all.
+dat: '1958'
+publia: St. Cloud Hospital School of Nursing
+dimens: 101.28 x 75.56
+genera: Health and Medicine
+type: Still Image
+physic: Studio portraits
+specif: Nurses; Nursing schools; Nursing students
+subjec: St. Cloud Hospital School of Nursing; St. Cloud School of Nursing; St. Raphael's
+  Training School for Nurses; Nursing school graduates; Central Minnesota nursing
+  schools;  Nursing education; Nursing schools; Sisters of the Order of Saint Benedict
+city: St. Cloud
+county: Stearns
+state: Minnesota
+countr: United States
+geogra: {}
+geonam: http://www.geonames.org/5044422/
+langua: English
+par: {}
+contra: CentraCare Health - St. Cloud Hospital
+contac: CentraCare Health - St. Cloud Hospital, 1406 Sixth Avenue North, St. Cloud,
+  MN 56303-1901; http://www.centracare.com
+righta: Use of this image is governed by U.S. and international copyright laws. Please
+  contact St. Cloud Hospital Archives for permission to publish this image.
+rights: {}
+use: {}
+rightb: {}
+expect: {}
+identi: scha-pne-0015
+resour: umn202215
+audio: {}
+audioa: {}
+video: {}
+projec: Minnesota Reflections 2012-13;
+fiscal: Funding provided to the Minnesota Digital Library through the Minnesota Arts
+  and Cultural Heritage Fund, a component of the Minnesota Clean Water, Land and Legacy
+  constitutional amendment, ratified by Minnesota voters in 2008.
+publis: University of Minnesota
+date: 9/14/2012 10:26
+format: image/jp2
+digspe: image/tiff
+digspa: '147794580'
+digspb: '24'
+digspc: '300'
+digspd: none
+digspf: '9006'
+digspg: '12591'
+digsph: Epson 10000XL scanner
+digspi: Adobe Photoshop CS
+digspj: Windows XP
+digspk: ee21a0a5f7f61bc4717c7e7c7fdbc5aa
+transc: "Class of 1950\n[Row one:] Helen Braun; Marian Palmer; Jeanniene [Jeannine]
+  Oien; Sr. M. Francesca [Zimmer], O.S.B.; Sr. M. Leonarda [Reinhart], O.S.B.; Sr.
+  M. Carmen [Mulcahy], O.S.B.; Geraldine Imgrund; Margaret Flynn; Mary Lou Sauer\n[Row
+  two:] Eunice Karls; Betty Muyres; Margaret Huebner; Marie Huelskamp; Elizabeth Gust;
+  Mary Lee Flory; Jeanette Rossmeisl; Donna Schoenecker; Jean Devine \n[Row three:]
+  Angela Schlegel; Jeanne Christenson; Irene Jansen; M. Dolores Frerich; Geraldine
+  Karels; Sidora Fiecke; Alvina Hennek; Ramona Frank; Theresa Bromenshenkel \n[Row
+  four:] Marcia Weber; Mary Miller; Marguerite Ehrnst; LaVerne Neeser; Dolores Yankowiak;
+  Clare Skluzacek; Joan Matson\n\nClass of 1951\n[Row one:] Barbara Baril; Dorothy
+  Ehresman; Sister Virgena [Virgene Marx], O.S.B.; Sister Joel [Stalberger], O.S.B.;
+  Glorianne Hofmann; Sister Martha [Schrantz], O.S.B.; Sister Loretta [Von Rueden],
+  O.S.F.; Rose Mary [Rosemary] McCarthy; Mary Jane Arnold\n[Row two:] Elaine Kosloski;
+  Mary Lou Schreiner; Evangeline Tomczik; Mary Ann Carriere; Luverne Tomczik; Patricia
+  Wilson; Jean [Jeanne] Fettig; Patricia Walsh; Eustelle Lauer\n[Row three:] Martha
+  Schaefer; Annella Botz; Dolores Plantenberg; Dorothy Kuchera; Jacquelyn Wampach;
+  Mary Ann Copa; Patricia Driscoll; Thelma Blunt; Lorraine Heim\n[Row four:] Mary
+  Agnes Zelka; Cecelia Schreifels; Elizabeth Schoenecker; Kathleen Doboszenski; Margaret
+  Fischer; Barbara Holty; Marcella Philipsek; Geraldine Hobbs; Priscilla Weidner;
+  Joan Reisinger\n[Row five:] Helen Brooks; Clara Beste; Anita Lussier; Loretta Thome;
+  Donna Kolb; Audrey [Mary Audry] Mergens; Janet Goerger; Phyllis Burgmeier; Kathleen
+  Reiten; Mary Lou Weber"
+transl: {}
+fullrs: {}
+find: 15.jp2
+dmaccess: {}
+dmimage: {}
+dmcreated: '2013-08-27'
+dmmodified: '2016-10-11'
+dmoclcno: '861237082'
+dmrecord: '14'
+restrictionCode: '1'
+cdmfilesize: '12279144'
+cdmfilesizeformatted: 11.71 MB
+cdmprintpdf: '0'
+cdmhasocr: '0'
+cdmisnewspaper: '0'
+page: []
+id: p16022coll31/14

--- a/spec/fixtures/contentdm/multipage_text.yml
+++ b/spec/fixtures/contentdm/multipage_text.yml
@@ -1,0 +1,4048 @@
+---
+title: Heatwole's Dairy Paper, Volume II, Number 10, December 1907
+photog: {}
+contri: Schilling, William F.
+descri: 'Heatwole''s Dairy Paper, Vol. II, No. 10, December 1907. Cover features the
+  program for the Minnesota State Dairymen''s Association 30th Annual Convention at
+  Northfield, Minnesota January 21-23, 1908. Cover story: A Great Dairy State, Four
+  Hundred Million Dollars Spent Annually for Nation''s Butter, How Minnesota Stands,
+  by W. W. Wall.'
+dat: '1907-12-01'
+publia: Joel P. Heatwole (Northfield, Minnesota)
+dimens: {}
+genera: Agriculture
+type: Text
+physic: Magazines (periodicals)
+specif: Agricultural education; Dairy farming; Dairy products industry;
+subjec: Agriculture
+city: Northfield
+county: Rice
+state: Minnesota
+countr: United States
+geogra: {}
+geonam: http://sws.geonames.org/5039676/
+langua: English
+par: {}
+contra: Northfield Historical Society
+contac: Northfield Historical Society, 408 Division Street, Northfield, Minnesota
+  55057
+rightc: No Copyright - United States
+rights: http://rightsstatements.org/vocab/NoC-US/1.0/
+rightd: The organization that has made the Item available believes that the Item is
+  in the Public Domain under the laws of the United States, but a determination was
+  not made as to its copyright status under the copyright laws of other countries.
+  The Item may not be in the Public Domain under the laws of other countries. Please
+  refer to the organization that has made the Item available for more information.
+public: {}
+identi: 86-25-2-1907-12-vii-n10
+resour: {}
+audio: {}
+audioa: {}
+video: {}
+projec: Minnesota Reflections 2012-13;
+fiscal: Funding provided to the Minnesota Digital Library through the Minnesota Arts
+  and Cultural Heritage Fund, a component of the Minnesota Clean Water, Land and Legacy
+  constitutional amendment, ratified by Minnesota voters in 2008.
+publis: {}
+date: {}
+format: {}
+digspe: {}
+digspa: {}
+digspb: {}
+digspc: {}
+digspd: {}
+digspf: {}
+digspg: {}
+digsph: {}
+digspi: {}
+digspj: {}
+digspk: {}
+transc: {}
+transl: {}
+fullrs: {}
+find: 578.cpd
+dmaccess: {}
+dmimage: {}
+dmcreated: '2021-01-27'
+dmmodified: '2021-01-27'
+dmoclcno: {}
+dmrecord: '806'
+restrictionCode: '1'
+cdmfilesize: '2482'
+cdmfilesizeformatted: 0.00 MB
+cdmprintpdf: '0'
+cdmhasocr: '0'
+cdmisnewspaper: '0'
+page:
+- pagetitle: Front cover
+  pagefile: 558.jp2
+  pageptr: '786'
+  title: Front cover
+  photog: {}
+  contri: {}
+  descri: {}
+  dat: {}
+  publia: {}
+  dimens: {}
+  genera: {}
+  type: {}
+  physic: {}
+  specif: {}
+  subjec: {}
+  city: {}
+  county: {}
+  state: {}
+  countr: {}
+  geogra: {}
+  geonam: {}
+  langua: {}
+  par: {}
+  contra: {}
+  contac: {}
+  rightc: {}
+  rights: {}
+  rightd: {}
+  public: {}
+  identi: {}
+  resour: umn251075
+  audio: {}
+  audioa: {}
+  video: {}
+  projec: {}
+  fiscal: {}
+  publis: University of Minnesota
+  date: 7/19/2013 15:11
+  format: image/jp2
+  digspe: image/tiff
+  digspa: '28051162'
+  digspb: '24'
+  digspc: '300'
+  digspd: none
+  digspf: '2629'
+  digspg: '3553'
+  digsph: i2s CopiBook
+  digspi: Adobe Photoshop CS
+  digspj: Windows XP
+  digspk: 7bae8ae954f239dbb31d0b9b2a166868
+  transc: "Heatwole's Dairy Paper.\nVol. II, No. 10\nNorthfield, Minn., December,
+    1907.\n50 Cents 3 Years\nMinnesota State Dairymen's Association\n30TH ANNUAL CONVENTION\nNorthfield,
+    January 21, 22, 23, 1908\nTUESDAY,  JANUARY 21\n10:30 a. m.\nCall to order by
+    President L. A. Sweet\nPrayer        ....      Rev. E. B. Dean\nAddress of Welcome
+    .    Mayor D. J. Eerguson\nResponse        .        .        S. B. Shilling, Chicago\nPresident's
+    Annual Address\nL. A. Sweet, Fairmont\nReport of Secretary   .   J. R. Morley,
+    Owatonna\nReport of Treasurer   .   Aug. Ahlswede; Jordan\nAppointment of Committees
+    on Resolutions, Audit and Legislation.\nTuesday, 2:00 p. m.\nQuack Grass\nCrop
+    Rotation\nValue of Clover\nDairy Cows\nC. O. Nichols, Northfield\nJohn Clifford,
+    Northfield\nE. Heffernan, Northfield\nGeo. H. Miller, Northfield\nAddress—B. D.
+    White, Assistant Chief Dairy\nDivision Department of Agriculture, Washington,
+    D. C.\nNutriment in Forage Crop—Prof. Harry Snyder,\nProfessor of Chemistry, School
+    of Agriculture.\nTuesday, 7:30 p. m.\nLiterary and Musical Program.\nWEDNESDAY,
+    \ JANUARY 22.\n9:30 A. M.\nForage for Dairy Cattle        ....\nA. D. Wilson,
+    Sup't Farmers Institutes\nTest Association     .     Colon C. Lillie, Michigan\nBreeding
+    Dairy Cattle—F. H. Scribner, Rosendale, Wis.\nVentilation Dairy Barns—Dr. M. H.
+    Reynolds,\nVeterinarian School of Agriculture,\nof Agriculture.\nWednesday, 2:30
+    p. m.\nAnnouncing Scores by Secretary J. R. Morley.\nCriticisms by Judges\t\nElection
+    of Officers *\nAddress—-Prof.  T.  L.   Haecker,  Professor  of\nDairy Husbandry,
+    School of Agriculture.\nCommunity Breeding        .        . .        .\nW. F.
+    Schilling, Northfield\nMoisture and Overrun        ....\nH. J. Credicott, Chicago\nTHURSDAY,
+    JANUARY 23.\n9:30 a. M.\nShall a co-operative creamery accept old stale\ncream
+    when in competition with a central-\nizer—C. F. Wendt, Welcome.\nThe Co-operative
+    Creamery vs. the Centralizer—\nA. H. Wheaton, Brookings, S. D., Dairy\nand Food
+    Commission, South Dakota.\nThe Centralizer vs the Co-operative Creamery—\nF. A.
+    Leighton, Manager Beatrice Creamery Co., Des Moines, Iowa.\nAddress—E. K. Slater,
+    Dairy and Food Commission, Minnesota.\nComparative expense and value of roots
+    and en-\nislage—A. J. McGuire, Northeast Experiment Station, Grand Rapids.\nThursday,
+    1:00 p. m.\nPublic sale of exhibit butter and cheese at exhibition hall.\n2:00
+    P. M.\nFarm and Creamery Accounts—J. A. Vye. Secretary School of Agriculture.\nConstitutional
+    Vigor in the Dairy—Forest Henry,\nDover.\nThe Silo        .        .        .
+    \       .        L. A. Sweet\nReports of Standing Committees.\nCo-operative Selling,
+    Robt. Crickmore, Chairman\nLegislative    .    Hon. T E. Cashman. Chairman\nInvestigation
+    Cream Rates      ....\nJ. R. Morley, Chairman\nUnfinished Business.\nAdjournment."
+  transl: {}
+  fullrs: Volume13/umn251075.tif
+  find: 558.jp2
+  dmaccess: {}
+  dmimage: {}
+  dmcreated: '2014-02-13'
+  dmmodified: '2014-02-13'
+  dmoclcno: {}
+  dmrecord: '786'
+  restrictionCode: '1'
+  cdmfilesize: '1082345'
+  cdmfilesizeformatted: 1.03 MB
+  cdmprintpdf: '0'
+  cdmhasocr: '1'
+  cdmisnewspaper: '0'
+  page: []
+  id: nfh/786
+- pagetitle: Inside front cover
+  pagefile: 559.jp2
+  pageptr: '787'
+  title: Inside front cover
+  photog: {}
+  contri: {}
+  descri: {}
+  dat: {}
+  publia: {}
+  dimens: {}
+  genera: {}
+  type: {}
+  physic: {}
+  specif: {}
+  subjec: {}
+  city: {}
+  county: {}
+  state: {}
+  countr: {}
+  geogra: {}
+  geonam: {}
+  langua: {}
+  par: {}
+  contra: {}
+  contac: {}
+  rightc: {}
+  rights: {}
+  rightd: {}
+  public: {}
+  identi: {}
+  resour: umn251076
+  audio: {}
+  audioa: {}
+  video: {}
+  projec: {}
+  fiscal: {}
+  publis: University of Minnesota
+  date: 7/19/2013 15:11
+  format: image/jp2
+  digspe: image/tiff
+  digspa: '29523140'
+  digspb: '24'
+  digspc: '300'
+  digspd: none
+  digspf: '2757'
+  digspg: '3566'
+  digsph: i2s CopiBook
+  digspi: Adobe Photoshop CS
+  digspj: Windows XP
+  digspk: e24a4c172abb64ce9b3f449f40386303
+  transc: |-
+    WBBRnWHEBK
+    UlSHSSBSSSSKIfUBSi' '
+    ^^^■■■■■■^^■■uwflBumBBHHHr'-'■'■■-
+    HEATWOLE'S DAIRY PAPER
+    Improve Your Dairy Cows
+    The only successful method of improving your dairy herd is through the
+    selection of a good dairy sire. No matter what kind of herd of cows you
+    may have, a good dairy sire of the oldest known breed in the world will help
+    you get better milkers. The high price of all the products of the dairy cow
+    makes it necessary to use better cows to get the best of your feed values and
+    when thinking over this proposition why not get the best? Get a cow that will
+    stand the weather and one that will eat all the rough feed on the farm and turn
+    it into a good profit. This means that you will strongly consider the merits of
+    the
+    Holstein-Friesian
+    before you purchase a sire. And why a Holstein ? Because they hold, unchallenged the world's official butter records for any age core for seven, fourteen,
+    thirty, sixty day or six months test and also hold all the official milk records of
+    the world. Then why are they not the best for the average farmer to raise?
+    They are large in size and are easy milkers.
+    Before You Purchase a Sire
+    do not fail to xorite to Spring Brook Farm, Northfield, Minn., to get prices,
+    breeding, etc. Here you will find ninety head of the very choicest animals in
+    the west and we now have on hand a dozen head of fine young sires.
+    One nearly white, 18 months old from a cow that has made an official
+    butter record of over twenty pounds of butter in seven days.
+    Another from Creamelle 2nd's Topsy Ann, whose daughter holds the
+    world's milk record of 26,280 pounds. This sire is just two years old and is a
+    very fine individual.   We have many others that are ready for service.
+    Write at once or call at any time
+    SPRING BROOK FARM
+    Only one mile from Northfield, Minn.
+  transl: {}
+  fullrs: Volume13/umn251076.tif
+  find: 559.jp2
+  dmaccess: {}
+  dmimage: {}
+  dmcreated: '2014-02-13'
+  dmmodified: '2014-02-13'
+  dmoclcno: {}
+  dmrecord: '787'
+  restrictionCode: '1'
+  cdmfilesize: '1235429'
+  cdmfilesizeformatted: 1.18 MB
+  cdmprintpdf: '0'
+  cdmhasocr: '1'
+  cdmisnewspaper: '0'
+  page: []
+  id: nfh/787
+- pagetitle: Page 1
+  pagefile: 560.jp2
+  pageptr: '788'
+  title: Page 1
+  photog: {}
+  contri: {}
+  descri: {}
+  dat: {}
+  publia: {}
+  dimens: {}
+  genera: {}
+  type: {}
+  physic: {}
+  specif: {}
+  subjec: {}
+  city: {}
+  county: {}
+  state: {}
+  countr: {}
+  geogra: {}
+  geonam: {}
+  langua: {}
+  par: {}
+  contra: {}
+  contac: {}
+  rightc: {}
+  rights: {}
+  rightd: {}
+  public: {}
+  identi: {}
+  resour: umn251077
+  audio: {}
+  audioa: {}
+  video: {}
+  projec: {}
+  fiscal: {}
+  publis: University of Minnesota
+  date: 7/19/2013 15:11
+  format: image/jp2
+  digspe: image/tiff
+  digspa: '28051162'
+  digspb: '24'
+  digspc: '300'
+  digspd: none
+  digspf: '2629'
+  digspg: '3553'
+  digsph: i2s CopiBook
+  digspi: Adobe Photoshop CS
+  digspj: Windows XP
+  digspk: c1faa2f01a29508199cb157b13e52dc0
+  transc: |-
+    Heatwole's Dairy Paper.
+    Vol. II, No. 10
+    Northfield, Minn., December, 1907.
+    50 Cents 3 Years
+    A GREAT DAIRY STATE
+    FOUR    HUNDRED     MILLION    DOLLARS SPENT ANNUALLY FOR
+    NATION'S BUTTER.
+    HOW MINNESOTA STANDS
+    Requires a Train  of Cars Two  Hundreds Miles Long to Carry
+    Country's Butter.
+    eries in 1907 will produce one hundred
+    million pounds of the best butter in
+    the world and it would require a train
+    of cars, each car containing 40,000
+    pounds, two hundred miles in length
+    to convey it to market. Don't these
+    figures impress you with the magnitude of the output and it must clearly
+    convince you of the great importance
+    of the industry and the responsibility
+    of the work of our department. Ten
+    per cent of the population of the United States is engaged in dairying, but
+    statistics show that fourteen of our
+    forty-five States produce the butter
+    which enters the great commercial centers.    Nearly two billion pounds are
+    The wonderful development of our
+    dairy resources in the past eighteen
+    years, and especially along co-operative lines, is the model and marvel of
+    other States; but in truth we must
+    say the Lord made our great commonwealth a dairy State and the wise and
+    helpful guidance of the State Dairy
+    & Food department and other splendid
+    educational forces have been a finger
+    board to the intelligent husbandman
+    to take the land and join the march
+    of progress. We say the Lord made
+    Minnesota a dairy State because He
+    adorned the 79,000 square miles of
+    our territory with ten thousand lakes
+    and spread upon the prairies the finest
+    grasses that grow in the world and
+    every lake, stream and blade of grass
+    has been an invitation to man to join
+    in the great work of making Minnesota the richest and most progressive
+    dairy region of the world. Already
+    about seventy-five thousand of our farmers have accepted the invitation and
+    are not only enriching the earth, but
+    are surely blessed from the storehouse of nature which sets the table
+    of the nation. We now have over nine
+    hundred and twenty-six creameries
+    and seventy-seven per cent of them
+    are owned and operated by the farmers. Their wonderful success proves
+    that the principle is fundamentally
+    right and that greater good will follow in the evolution of the business.
+    No industry is doing more for the material well being of our people than
+    that of tbe dairy, and no department
+    of the State government comes in
+    closer touch with the producer of our
+    vast dairy wealth than does the Dairy
+    & Food department   Minnesota cream-
+    WILLIAM W. WALL,
+    Secretary State Dairy and Food Commission, Minnesota.
+    The man who has done much to advance the dairy interests of Minnesota to the front rank.
+    made and sold annually in the United
+    States. This would give a return of
+    nearly four hundred million dollars
+    for butter alone. This may seem incredible to the average mind, but statistics tell us that butter furnishes
+    19.7 per cent of the total fat in the
+    average American diet. The average
+    consumption in this country is about
+    twenty pounds per capita and the best
+    product finds a ready sale. The valua
+    of dairy products of the United States
+    is almost five per cent of all our agricultural products. It is also shown by
+    statistics that 94 per cent of the butter made in this country is consumed
+    by our own citizens.
+    But let me return to the facts showing the growth of the co-operative idea
+    in the ownership and management of
+    Minnesota creameries.   On June 16th,
+    1890  the  first  co-operative   creamery
+    in    Minnesota    was    established    at
+    Clark's Grove, Freeborn county.    On
+    July 31st, 1892 there were 266 creameries in our State and only thirteen
+    of these were co-operative.   On March
+    1st, 1894 our records show that there
+    were  253  creameries  doing  business
+    within our boundaries, being 12 less
+    than there were in 1892; but the num
+    ber of co-operative creameries had increased from 13 to 164, plainly show
+    ing the evolution of the great industry.
+    In 1896 there were 445 creameries of
+    which 302 were co-operative.    This is
+    a good showing as there were 148 more
+    co-operative creameries in 1896 than
+    there were in 1894.    Taking the r«c
+    ords of 1898 we find that there were
+    551 creameries in Minnesota of which
+    number 419   were   conducted on   the
+    co-operative   basis.     This   is   a  gain
+    of 117 in two years showing the steady
+    growth of the co-operative idea among
+    our farmers. The biennial period from
+    1898 to 1900 was not productive of so
+    large an increase in the  total number of creameries,  there being only
+    582—but thirty-one   more than    were
+    operated in 1898.   The number operated on a co-operative basis increased
+    from 419 to 438. During the two years
+    from 1900 to 1902 our creameries increased  from  582  to  690—a gain oi
+    108 and there was a gain of 89 in the
+    co-operative  class.    The   biennial  report of 1904 gives the total number
+    of creameries at 770 of which 572 were
+    co-operative.    In 1906 the number of
+    creameries, reporting   to this department was 926 of which 719 were cooperative.    The increase  in the production of creamery butter has been
+    quite phenomenal   as   the   following
+    table proves:
+    j Year.   Pounds of Butter Paid Patrons
+    1900
+    44,007,933
+    $ 6,959,914.55
+    1902
+    63,726,808
+    10,941,468.39
+    1903
+    72,206,348
+    12,988,688.21
+    1904
+    78,455,459
+    12,994,460.55
+    1906
+    89,756,260
+    13,747,422.30
+    List
+    of counties
+    which produced
+    IMPul
+  transl: {}
+  fullrs: Volume13/umn251077.tif
+  find: 560.jp2
+  dmaccess: {}
+  dmimage: {}
+  dmcreated: '2014-02-13'
+  dmmodified: '2014-02-13'
+  dmoclcno: {}
+  dmrecord: '788'
+  restrictionCode: '1'
+  cdmfilesize: '1287458'
+  cdmfilesizeformatted: 1.23 MB
+  cdmprintpdf: '0'
+  cdmhasocr: '1'
+  cdmisnewspaper: '0'
+  page: []
+  id: nfh/788
+- pagetitle: Page 2
+  pagefile: 561.jp2
+  pageptr: '789'
+  title: Page 2
+  photog: {}
+  contri: {}
+  descri: {}
+  dat: {}
+  publia: {}
+  dimens: {}
+  genera: {}
+  type: {}
+  physic: {}
+  specif: {}
+  subjec: {}
+  city: {}
+  county: {}
+  state: {}
+  countr: {}
+  geogra: {}
+  geonam: {}
+  langua: {}
+  par: {}
+  contra: {}
+  contac: {}
+  rightc: {}
+  rights: {}
+  rightd: {}
+  public: {}
+  identi: {}
+  resour: umn251078
+  audio: {}
+  audioa: {}
+  video: {}
+  projec: {}
+  fiscal: {}
+  publis: University of Minnesota
+  date: 7/19/2013 15:12
+  format: image/jp2
+  digspe: image/tiff
+  digspa: '29523140'
+  digspb: '24'
+  digspc: '300'
+  digspd: none
+  digspf: '2757'
+  digspg: '3566'
+  digsph: i2s CopiBook
+  digspi: Adobe Photoshop CS
+  digspj: Windows XP
+  digspk: 327046e5cf047bb9cc12102da94231f5
+  transc: |-
+    u^mnsnnBHBHn
+    •■^Kf
+    *^5
+    HEATWOLE'S DAIRY PAPER
+    over 1,000,000 pounds of creamery butter in the year 1906.
+    Co-op. Ind.
+    Blue Earth    1,693,743 15 1
+    Brown       1,570,067. 16 1
+    Carver     2,237,093 9 14
+    Chisago  1,348,985 11 2
+    Fillmore       1,507,927 8 2
+    Freeborn     3,969,293 28
+    Faribault    2,336,956 22 1
+    Goodhue    1,417,636 11 3
+    Kandiyohi   ....  1,300,516 14 2
+    Martin      1,250,580 12 1
+    Le Sueur    1,001,135 6 8
+    Mower     1,140,819 13 2
+    Meeker   2,183,667 17 3
+    McLeod     2,531,132 13 8
+    Nicollet     1,426,738 13
+    Olmsted    1,615,225 16 1
+    Redwood    1,021,576 16 3
+    Renville     1,197,211 16 5
+    Rice     1,548,334 11 S
+    Steele    3,542,262 20 3
+    Sibley      1,335,488 11 2
+    Stearns     2,892,731 29 12
+    Wright      2,666,267 20 8
+    Winona     1,512,960 16 4
+    Waseca     1,986,512 18 2
+    Total 46,853,653     380       91
+    In no other State in the union has
+    the co-operative idea been so generally adopted in the operation of creameries as in Minnesota, and in some
+    States the central plants have almost
+    crushed out the smaller plants. Time
+    will further demonstrate that the co
+    operative scheme is the proper one,
+    and here permit me to say that there
+    is no more promising field open to the
+    industrious home builder than Is offered in the North Star State.
+    —W. W. WALL.
+    SPARE THE BIRDS.
+    Think of a Few Things Next Time
+    You   Shoot  Birds.
+    "Our hours," said a nature student,
+    "are nothing to the birds. Why, some
+    birds work in summer nineteen hours
+    a day. Indefatigably they clear the
+    crops of insects.
+    "The thrush gets up at 2:30 every
+    summer morning. He rolls up his
+    sleeves and falls to work at once, and
+    he never stops till 9:30 at night. A
+    clean 19 hours. During that time he
+    feeds his voracious young 206 times.
+    "The blackbird starts work at the
+    same time as the thrush, but he lays
+    off earlier. His whistle blows at 7:30,
+    and during his seventeen-hour day he
+    sets about 100 meals for his kiddies.
+    "The titmouse is up and about by
+    three o'clock in the morning and his
+    stopping time is nine o'clock at night.
+    A fast worker, the titmouse is said to
+    fed his young 417 meals—meals of
+    caterpillar mainly—in the long, hard,
+    hot day."
+    He who locks his tongue in locks
+    a good deal of trouble out.
+    TRUE TYPE HOLSTEIN
+    THE RESULT OF CENTURIES OF
+    SHREWD SELECTION AND
+    PROPER CARE.
+    AMERICAN ANIMALS FINER
+    Some   Expert   Opinions   of   the   True
+    Type  of the   Breed—Results  of
+    Scientific  Study.
+    We are indebted to Mr. F. L. Houghton of Brattleboro, Vermont, secretary of the National Holstein-Freisian
+    Association, for the following interesting article:
+    Considerable public comment on the
+    type of Holstein-Friesian cattle is appearing in the agricultural papers is
+    very properly directing attention to
+    the subject of the true type of the
+    breed.
+    The breeder, who, for one moment
+    is his pursuit of higher fat percentage in the milk, forgets type, is doing incalculable damage to the future
+    of  the  breed.
+    The true type of the breed is very
+    accurately delineated in the scale of
+    points. It is to be regretted that illustrations of typical specimens are
+    not used to illustrate and emphasize
+    this   description.
+    Change of environment of this
+    breed from the low lands of Holland
+    is doubtless effecting a very slight
+    change in the bony structure of the
+    Holstein, tending toward a greater
+    finish or refinement. Aside from this
+    natural process, it is very doubtful
+    whether any improvement can be
+    made or should be attempted. The
+    Holland type is the result of centuries of selection and environment,
+    and it has distinguished these cattle
+    in all parts of the world. With it has
+    come the marvelous and profitable
+    production or yield, the characteristic
+    tendencies of powerful digestion and
+    perfect assimilation of food. These
+    characteristics, derived from the Holstein, have been important factors in
+    the foundation stock of the Shorthorn and Ayshire breeds and of many
+    Continental off-shoots.
+    In America it was the Holland type
+    that by its productice power directed
+    the attention of agriculturists towards
+    this breed, and it is safe to assert
+    that an examination of the great majority of remarkable yields will show,
+    to those having means of access to
+    photographs or descriptions, the close
+    adherence to the Holland type in all
+    these wonderful animals. Large size
+    in the Holstein is the first thing to
+    impress the casual observer, and its
+    importance should never be disregarded. In defining pure bred Holstein
+    cattle, this fact was duly set forth by
+    the founders of the herd-book association, in these words, which should never be forgotten, no matter what may
+    be the yield in milk or its fat percentage, viz: "Pure bred Holstein-
+    Friesian shall be held to mean and
+    refer to only those large, improved
+    black and white cattle, etc." (Art. 4,
+    Section 5, By-Laws of H. F. A. of A.)
+    Scientific investigation in this country, particularly in Wisconsin, has
+    confirmed the wisdom of the early
+    breeders in thus defining the type
+    of the breed as "large," for the large
+    cow of any bred is uniformly the
+    more profitable. An idea of the size
+    of animals of this breed, at the time
+    of Mr. Chenery's first importations,
+    may be gained from the following
+    quotation. (Vol. 2 Holstein H. B. folio
+    19). "The bill, Van Tromp (see portrait) imported in the womb of Texe-
+    laar, is now six years old, and his
+    girth is 8 feet 5 inches; length, 9 feet
+    2 inches; height, 5 feet 2 inches;
+    weight, 2,700 pounds; and the weignc
+    of the two-years-old bull, Opperdoes
+    7th, is 1,597 pounds. The weight of
+    the imported cow, Texelaar (see portrait), is 1,560 pounds; Lady Mid-
+    would (see portait), 1,620 pounds; the
+    four-year-old heifer, Opperdoes 3d
+    (see portait), 1,495 pounds; the three-
+    years-old heifer, Texelaar 6th, 1,500
+    pounds; the two-years-old heifer, Texelaar 8th, 1,290 pounds; the yearling
+    heifer, Zuider Zee 5th, 900 pounds;
+    the bull-calf, Duke of Belmont, nine
+    months old, 710 pounds, and the heifer
+    calf, Midwould 8th, nine months old,
+    G35 pounds; all raised in the ordinary way, without forcing, the young
+    animals running in pasture from May
+    until November."
+    Burton W. Potter, in 1906, published the results of his investigations as
+    to the weight of sixty large record
+    cows, tested under the present Advanced Registry system, 1894 to 1906.
+    Mr. Potter summarizes thus: "Of
+    the sixty cows, only thirteen weigh
+    more than 1,500 pounds each and
+    only twenty-seven surpass the 1,400
+    pound mark. Only nine weigh less
+    than 1,200 pounds, and the average
+    weight of the whole number is 1,383
+    pounds, etc. "Of the twenty-five
+    bulls, not one weighs less than 1,800
+    pounds and only five less than 2,000
+    pounds. Only three weigh more than
+    2,400 pounds, and the average weight
+    of the whole number is 2,164 pounds.
+    Mr. S. Hoxie, in the pamphlet, "Holstein-Friesian cattle" (1905) writing
+    upon the size of cows, states, "In ordinary milking condition at full age,
+    they range in weight from 1000 to
+    1500 pounds."
+    With large size  as the recognized
+  transl: {}
+  fullrs: Volume13/umn251078.tif
+  find: 561.jp2
+  dmaccess: {}
+  dmimage: {}
+  dmcreated: '2014-02-13'
+  dmmodified: '2014-02-13'
+  dmoclcno: {}
+  dmrecord: '789'
+  restrictionCode: '1'
+  cdmfilesize: '1413408'
+  cdmfilesizeformatted: 1.35 MB
+  cdmprintpdf: '0'
+  cdmhasocr: '1'
+  cdmisnewspaper: '0'
+  page: []
+  id: nfh/789
+- pagetitle: Page 3
+  pagefile: 562.jp2
+  pageptr: '790'
+  title: Page 3
+  photog: {}
+  contri: {}
+  descri: {}
+  dat: {}
+  publia: {}
+  dimens: {}
+  genera: {}
+  type: {}
+  physic: {}
+  specif: {}
+  subjec: {}
+  city: {}
+  county: {}
+  state: {}
+  countr: {}
+  geogra: {}
+  geonam: {}
+  langua: {}
+  par: {}
+  contra: {}
+  contac: {}
+  rightc: {}
+  rights: {}
+  rightd: {}
+  public: {}
+  identi: {}
+  resour: umn251079
+  audio: {}
+  audioa: {}
+  video: {}
+  projec: {}
+  fiscal: {}
+  publis: University of Minnesota
+  date: 7/19/2013 15:12
+  format: image/jp2
+  digspe: image/tiff
+  digspa: '28051162'
+  digspb: '24'
+  digspc: '300'
+  digspd: none
+  digspf: '2629'
+  digspg: '3553'
+  digsph: i2s CopiBook
+  digspi: Adobe Photoshop CS
+  digspj: Windows XP
+  digspk: c101639eb9e6d159c6bd7f4e849d0cea
+  transc: |-
+    HEATWOLE'S DAIRY PAPER
+    predominent characteristic of the
+    breed, aside from their beautiful black
+    and white color markings in perfectly defined patches or spots, the next
+    general definition relates to the general conformation of the animal. There
+    are three definite types, described as
+    the milk and beef form, the milk
+    lorm, and beef and milk form.
+    The average form of this breed
+    and that toward which conscientious
+    breeders are directing their efforts to
+    maintain and improve, is the milk and
+    beef form.
+    Mr. S. Hoxie thus admirably refers
+    to the milk and beef type of the
+    breed: "It is especially strong in all
+    vital particulars. The bones are fine
+    compared with size, and the chine
+    broad, and strong compared with the
+    high and sharp chine of the extreme
+    milk form. The loin and hips are
+    broad and smooth, and the rump high
+    and level, compared with the angularity usually shown in the milk form.
+    The twist is roomy and the thighs
+    and hocks well apart. Passing forward the shoulders are smoother and
+    more compact than in the milk form,
+    but of lighter weight than in the beef
+    form. The brisket is not so wide and
+    low as in the beef form, and the chest
+    is not so deep, but the width of the
+    beef form through at the heart is closely retained. In the milk form the abdomen is usually swung low, and the
+    ribs are steep, but in the milk and
+    beef form the ribs are wider sprung
+    and the abdomen more trimly held
+    up though no less capacious. The
+    general appearance of the bull is
+    strongly masculine, but that of the
+    cow is no less femine than in the milk
+    form."
+    It may be further emphasized, that
+    the milk and beef form, describes a
+    cow of the wedge form, with shoulders moderately thick, deep and broad
+    crops well filled, barrel well rounded,
+    loin and hips broad and full, and
+    quarters straight, wide and full.
+    To this form of these cattle is due
+    their extraordinary constitutional vigor or vital force, and it affects all
+    their relations to their good, care and
+    productions.
+    The milk and beef form is not accompanied with the angularity of appearance, the light shoulders and
+    chest, and the comparatively light
+    quarters of cattle of the milk form.
+    The future of the breed will be
+    greatly endangered by those, who,
+    from one consideration or another,
+    the combination of pedigrees to attain large average records or fat percentages, or by neglect of proper feed
+    and care in the early life of the animal, are led to the mating of animals
+    of other than those of large size, and
+    possessing the milk and beef form.
+    Neither the breeds of the Channel
+    Islands nor the Ayshire breed possesses this form, even ranio1;ly.
+    Second Annual Auction=75 Head Holstein-
+    Friesian Cattle, Tuesday, January 14, 1908
+    AOhanro s\f «a I   ifo T ima Make Your Own Selections anc
+    UnanC6 OT a Lite   I ime Buy Them At Your Own Price
+    d
+    y Tnem At  rour own Price
+    IB PtuBIc Sons and grandsons of Paul Beets DeKol (champion sire of the breed),
+    ■** mMMm.t9 Hengerveld De Kol. Pearl of the Dairy, Joe Do Kol, Aaggie Cornucopia
+    Johanna Lad and others. These bulls are out of A. R. O. dams and close!}' related to Aaggie
+    Cornucopia Pauline i world's chompion cow up to 1907), Canary Mercedes, Segis Inka, Alcartra Polkadot and others.
+    &/%  Vmitmrt fniMMtc from two years and up.   Some with A. K. 0. records.
+    «*■»   ■ t/MMfJ %MVW3S Several coming fresh this winter and spring.
+    9/1 Uaj|T<aM Paliras Two months up to fifteen months in age.   A fancy lot
+    *.** n%SIWfSr vjicmlVtZS* jn color and quality and bred from the best lines-
+    Cattle going out of the state will be tuberculin tested free of charge.
+    Catalogues will be ready before the sale. Any information will be cheerfully given by mail.
+    R. E. HARCER, Algonquin, McHenry County, III.
+    ROBT. HARCER, Auct 50 miles northwest of Chicago-
+    BUTTER A  FINISHED  PRODUCT.
+    Farmers Should Join Hands and Own
+    The Creameries.
+    J. R. Morley, of Owatonna, the gentleman who spoke on the subject of
+    co-operative creameries here last Saturday, made a strong plea for loyal
+    support of home creameries. He believes that every creamery should be
+    owned by the farmers. In this way
+    only can they get for their cairy
+    products the best the market aifords.
+    Farmers who ship their cream and
+    do not patronize the home creamery,
+    if there is one to patronize, make a
+    mistake. But the greatest mistake
+    Mr. Morley thinks is for the farmers
+    not to own their own creameries This
+    line of business belongs to them and
+    no one else and they should take advantage of that fact and go in to niako
+    the most of it. There is no good reason why the farmer should not himself market the finished product of the
+    dairy. No good reason why the farmer should not sell butter instead of
+    cream. It is not convenient for a
+    farmer with a large dairy herd to convert all his cream into butter. But it
+    is convenient for that same farmer
+    to join hands with other farmers similarly situated and for all of them to
+    make their butter in common. This
+    is what the local creamery does. It
+    makes butter for the community. It
+    is the common churn to which all the
+    farmers of a given locality bring their
+    cream and have it turned into butter. Is it not plain that such an institution should be owned, controlled and operated by the farmers themselves? Every industry should endeav
+    or as far as practicable to dispose of
+    a finished product. Cream is not a
+    finished product of the dairy. Butter
+    is. The finished product commands
+    so much higher price than the raw
+    material that in the conversion of one
+    into the other lies the largest share
+    of net profit. Why should not the farmer have this profit rather than someone else? Some say that local creameries are as a rule a failure. Where
+    this has been the case one can in nearly every instance find the cause in
+    some local condition, Poor management, the wrangling of local promot
+    ers and lack of support are as a rule
+    the principal sources of trouble. Farmers must learn to overcome these
+    things and having done so they will
+    find that no field of co-operation is
+    more profitable than that connected
+    with ' the dairy business.—Minneota
+    Mascot.
+    STICK   TO   THE   FARM.
+    The Urban Life is the Most Dignified and Pleasant.
+    A good living is what comparatively
+    few man succeed in making in village
+    or city life, and yet nothing is more
+    easy of accomplishment on the farm.
+    Besides, there is a pleasure in cultivating and embellishing the earth,
+    improving and increasing its products, and thus adding to the aggregate of human happiness, why, then,
+    should you men hesitate to be farmers' It is both profitable and honorable. It is the nearest approximation to independence that a man, or
+    a member of society, can make. A
+    gentleman farmer—and all farmers
+    are or should be, gentlemen—belongs
+    to an order of nobility that is not indebted to placeholders for installation, and may, if he chooses, be ranked among the greatest benefactors of
+    the human race.
+    KEEP   GOOD   NATURED.
+    Cultivate a Sunny Disposition and
+    Follow Golden Rule.
+    No matter how disagreeable your
+    work, or how much trouble you may
+    have, resolve that, whatever comes to
+    you, you will not allow your disposition to sour, that you will face the
+    sunlight, no matter how deep the shadows. You can make poetry out of the
+    prosiest life, and bring sunshine into
+    the darkest home; you can develop
+    beauty and grace amid the ugliest
+    surroundings. It is not circumstances,
+    so much as attitude of mind, that gives
+    happiness. Who can estimate the value
+    of a nature so sunny that it attracts
+    everybody. Everybody wants to get
+    near sunny people; everybody likes to
+    know them. They open, without effort, doors which morose natures are
+    obliged to pry open with great difficulty, or perhaps cannot open at all.
+    ,•• «&
+  transl: {}
+  fullrs: Volume13/umn251079.tif
+  find: 562.jp2
+  dmaccess: {}
+  dmimage: {}
+  dmcreated: '2014-02-13'
+  dmmodified: '2014-02-13'
+  dmoclcno: {}
+  dmrecord: '790'
+  restrictionCode: '1'
+  cdmfilesize: '1014716'
+  cdmfilesizeformatted: 0.97 MB
+  cdmprintpdf: '0'
+  cdmhasocr: '1'
+  cdmisnewspaper: '0'
+  page: []
+  id: nfh/790
+- pagetitle: Page 4
+  pagefile: 563.jp2
+  pageptr: '791'
+  title: Page 4
+  photog: {}
+  contri: {}
+  descri: {}
+  dat: {}
+  publia: {}
+  dimens: {}
+  genera: {}
+  type: {}
+  physic: {}
+  specif: {}
+  subjec: {}
+  city: {}
+  county: {}
+  state: {}
+  countr: {}
+  geogra: {}
+  geonam: {}
+  langua: {}
+  par: {}
+  contra: {}
+  contac: {}
+  rightc: {}
+  rights: {}
+  rightd: {}
+  public: {}
+  identi: {}
+  resour: umn251080
+  audio: {}
+  audioa: {}
+  video: {}
+  projec: {}
+  fiscal: {}
+  publis: University of Minnesota
+  date: 7/19/2013 15:12
+  format: image/jp2
+  digspe: image/tiff
+  digspa: '29523140'
+  digspb: '24'
+  digspc: '300'
+  digspd: none
+  digspf: '2757'
+  digspg: '3566'
+  digsph: i2s CopiBook
+  digspi: Adobe Photoshop CS
+  digspj: Windows XP
+  digspk: 6cc2ee2e4aa492051d261b90da57db5d
+  transc: "HEATWOLE'S DAIRY PAPER\nA THIRTY MILE T\nRICE     COUNTY     HAS     MADE
+    \    IN\nSEVEN YEARS TEN  MILLION\nPOUNDS OF BUTTER.\nALSO GREAT MILK YIELD\nIt
+    \   Would    Require    a    Train    Thirty\nMiles   Long   to   Haul   the   Rice\nCounty
+    Products to Market.\nRice county though one of the smallest counties of Minnesota,
+    containing\nbut 497 square miles, is one of the\nbanner dairy counties of the
+    State.\nThe county was organized in 1853 and\nwas named in honor of Hon. Henry\nM.
+    Rice, who came to the territory\nin 1839, and who later represented the\nState
+    in the United States senate.\nEven your pioneer settlers found the\ncounty eminently
+    suitable for dairying and were aided in their efforts\nat home-building by the
+    cow with the\n\"crumpled horn.\" In I860 Rice county had a population of 7,543
+    and in\n1905 it had reached 26,247. As in other counties, in pioneer days, the
+    farmers of Rice county raised and hauled wheat long distances to market;\nbut
+    we find by our records that as\nearly as 1886 dairying had become a\nfixed idea,
+    and rightfully so, among\nyour husbandman, in fact they were\nthen supplying milk
+    to five creameries\nand three cheese factories, and were\nlaying the foundation
+    for the future\nsuccess of the great industry which\nhas done so much for the
+    name and\nfame of the North Star State.\nIn 1888 Minnesota had 146 creameries,
+    all operated under private ownership, and Rice county contained two,\na loss of
+    one In two years.\nTaking our records for 1890 we find\nthat your county had three
+    creameries,\na gain of one, but In 1892 the number\nhad increased to eleven. Between\n1892
+    and 1894 there was a recession\nin the number for in the latter years\nonly five
+    creameries were reported in\noperation. In that year there were but\n253 creameries
+    in the State, a gain of\n107 in six years. In 1896 the number of creameries in
+    the county had\nincreased from five to twelve and in\nthe State the number had
+    increased\nfrom 253 to 445, and most of the new\nplants were on a co-operative
+    basis.\nOur records show that in 1898 Rice\ncounty had eighteen creameries, the\nlargest
+    number in its history, and in\nthat year we notice that Joseph Plon-\nty, of Morristown,
+    and W. I. Noyes, of\nMoland, secured scores in the State\ncontests of 97% and
+    95%.   This was\nYour Profits Are Cut\nAt FOUR Points by ABORTION\n1. You Lose
+    Calves, thus preventing a natural increase In your herd.\n2. You lose Milk, a
+    direct money loss.\n3. You Lose Cows, for an unprofitable cow must be disposed
+    of, or she eats\nher head off, a loss in either case.\n4. You Lose Time and Labor
+    in caring for a diseased cow, besides running\nthe risk of infecting the entire
+    herd.\nYou can stop all this loss by stamping out the disease with Dr. David Roberts'\nAnti-Abortion
+    Serum Treatment. You can administer the treatmentyourself.\nThis Is what Dr. A.
+    S. Alexander, of the \"Wisconsin Experimental Station says In\nreply to an inquiry
+    in regard to the Roberts'Treatment for Abortion: \"I must\nconfess that I cannot
+    prescribe anything for contagious abortion that gives as good\nresults as those
+    obtained from the use of Dr. David Roberts' Anti-Abortion Serum,\nwhich to my
+    knowledge has succeeded where thorough application of an anti\nseptic treatment
+    advised by me had failed\nto stay or prevent the disease.   His other\n. remedies
+    are also reliable and worthy of\nI extended use by stockmen.\"\nZj22>\\      ItlJML3i1iM£tsrl1rflP
+    \     Your herd may be infected with abortion\nyj£iBmm$ ■ without showing positive
+    symptoms.   If\ni there is a falling off In the flow of milk or\nin the quality.
+    If your cows are run down\nVETERINARIAN\nor are out of condition, you ought to
+    ex\namine them and make tests for Abortion.\nEven if they are in apparent good
+    condl\ntion, one or more of them may have the\ngerms of contagious abortion in
+    the system. It will cost you nothing to And out\nif your cows are affected, and
+    the sooner\nyou make the test the more you will save\nW   in time and money.\nAek
+    for **The Practical Home Veterinarian.\"    It\ntells all about abortion: how
+    to detect It and how to\nStampitout. It is FREE. This book is the published results\nof
+    Dr. David Roberts' twenty years experiments and veterinary experience with the
+    disease of Abortion. It is a $1.00\ncloth bound book. Cut out the coupon below
+    and sendit today with 10c postage.   If you send at once we will put you on the
+    free list of \"The Cattle\nSpecialist,\" a monthly live stock journal.\nAPneirivo
+    ftlinrnTl+ao We guarantee to wipe out the germs of contagious\nJrUBlUVe niUliaiUU-
+    Abortion in every case where Dr. Roberts' Anil\nAbortion Serum is used as directed
+    In \"The Practical Home Veterinarian.\" In case\nof failure we return the cost
+    of treatment.\nA public recognition of Dr. Roberts' thoroughness and eminence
+    as a veterinarian was his recent appointment as State Veterinarian of Wisconsin,\none
+    of the greatest dairy states. The fact that hundreds of herds ha\\e been successfully
+    treated—not one unsuccessfully—tells why we can guarantee the\ntreatment. Send
+    the Free Book Coupon while you have it in mind. The\nbook is a complete guide
+    in treating all live stock diseases.\nDr. David Roberts Veterinary Co., „      Grand
+    Ave., Waukesha, Wis.\n$1.00 Free\nBOOK COUPON\nDK. DAVID ROBERTS VETERINARY CO.,
+    6    Srand Ave., Waukesha, Wis.\nI own cows horses hogs Bheep poultry. ■ Please
+    send me\nFREE the \"Practical Home Veterinarian.   I enclose 10c for postage.\nName..\nR.
+    F. D. No P. O State\t\nAlso send \"The Cattle Specialist\" FREE for one year.\nthe
+    quality that gave our State its\nhigh standing at the Omaha exposition.\nIn the
+    year 1900 we find only seventeen creameries in operation in Rice;\nbut they were
+    \"going some\"; for they\nproduced 1,988,011 pounds of butter\nand your farmers
+    received for their\nmilk  $333,381.09.\nRice has for years been in the list\nof
+    dairy counties which have produced\nover a million pounds of butter annually.\nThe
+    following table tells the story\nof your butter production for seven\nyears, and
+    it speaks eloquently.\nCream-   Pounds\nPaid\nYear\neries     of butter.\nPatrons\n1900\n17
+    \      1,988,011\n% 333,381.09\n1901\n17        1,120,295\n197,141.06\n1902\n17
+    \       1,326,114\n204,136.10\n1903\n18        1,352,236\n237,279.70\n1904\n19
+    \       1,548,334\n248,305.54\n1905\n16        1,678,212\n263,214.26\n1906\n17
+    \       1,478,332\n290,398.85\n10,491,534        1,773,856.60\nThink of it 10,491,534
+    pounds of butter and remember it would require a\ntrain of cars thirty miles in
+    length to\nhaul it to market.\nMinnesota  in    1907    will  produce\nabout one
+    hundred million pounds of\nbutter, and Rice county is grandly\naiding in the good
+    work.\n—W. W. WALL.\nDairy Cows in Wisconsin.\n\"Leaders of dairy thought and
+    practice in Wisconsin pin their faith to\nthe special-purpose dairy cows,\" said\nState
+    Dairy and Food Commissioner\nJ. Q. Emery in a recent address. \"To\ntheir intelligent,
+    considerate care, she\nresponds most generously, giving to\nthem abundantly of
+    her golden riches,\nand they have yielded their purposes,\nhopes and business
+    destiny to the sovereign sways of that gentle, gifted\ndairy queen. This policy
+    has resulted\nin the production of splendid herds\nof distinctly dairy cows that
+    have\nproven highly remunerative to their\nowners, and has given to Wisconsin\nand
+    to the dairy world a Brown Bessie, a Loretta D, a Yeksa Sunbeam and\na Colantha
+    4th's Johanna.\"\nBe sure that the bull is properly exercised and a very good
+    way to do\nthis is to make a sweep and put him\nout on it daily and you will have
+    no\ntrouble about his being a sure breeder.\nDo not feed the bull intended for
+    breeding much corn."
+  transl: {}
+  fullrs: Volume13/umn251080.tif
+  find: 563.jp2
+  dmaccess: {}
+  dmimage: {}
+  dmcreated: '2014-02-13'
+  dmmodified: '2014-02-13'
+  dmoclcno: {}
+  dmrecord: '791'
+  restrictionCode: '1'
+  cdmfilesize: '1616134'
+  cdmfilesizeformatted: 1.54 MB
+  cdmprintpdf: '0'
+  cdmhasocr: '1'
+  cdmisnewspaper: '0'
+  page: []
+  id: nfh/791
+- pagetitle: Page 5
+  pagefile: 564.jp2
+  pageptr: '792'
+  title: Page 5
+  photog: {}
+  contri: {}
+  descri: {}
+  dat: {}
+  publia: {}
+  dimens: {}
+  genera: {}
+  type: {}
+  physic: {}
+  specif: {}
+  subjec: {}
+  city: {}
+  county: {}
+  state: {}
+  countr: {}
+  geogra: {}
+  geonam: {}
+  langua: {}
+  par: {}
+  contra: {}
+  contac: {}
+  rightc: {}
+  rights: {}
+  rightd: {}
+  public: {}
+  identi: {}
+  resour: umn251081
+  audio: {}
+  audioa: {}
+  video: {}
+  projec: {}
+  fiscal: {}
+  publis: University of Minnesota
+  date: 7/19/2013 15:12
+  format: image/jp2
+  digspe: image/tiff
+  digspa: '28051162'
+  digspb: '24'
+  digspc: '300'
+  digspd: none
+  digspf: '2629'
+  digspg: '3553'
+  digsph: i2s CopiBook
+  digspi: Adobe Photoshop CS
+  digspj: Windows XP
+  digspk: 0a5d4dc4a9c25c0aa5a9d7dc13b6441b
+  transc: |-
+    HEATWOLE'S DAIRY PAPER
+    UNSANITARY COW STABLES.
+    What Prof. Pearson of the Pennsylvania Station Has Discovered.
+    We have called the attention of our
+    readers, and especially those who are
+    engaged in dairying, to the necessity
+    of having sanitary stables as well as
+    sanitary homes. By way of adding
+    emphasis to what we have already
+    said we call their attention to an address delivered by Prof. R. A. Pearson, giving the result of an experiment lasting seventeen months at the
+    Pennsylvania Experiment Station, as
+    follows:
+    Two herds of six cows each were
+    kept in two stables. In each lot were
+    two cows known to be tuberculous and
+    four that were known to be healthy.
+    A tuberculous cow was placed between
+    the healthy cows in each stable. The
+    tuberculous cows were frequently
+    changed from one stable to the other,
+    so that the healthy cows in each stable
+    should have the same exposure. One
+    stable -was light, roomy, clean, and
+    well ventilated; the other dark,
+    small, unclean, and poorly ventilated.
+    At the end of seventeen months all
+    the cows were killed. In the unsanitary stable all that were healthy when
+    they went In were found to be badly
+    diseased. In the sanitary stable two
+    of the healthy cows had contracted
+    the disease, but were not in nearly
+    as b?d a condition as those in the
+    unsanitary stable.
+    This experiment shows that although
+    sanitation will not prevent cattle from
+    contracting tuberculosis, if they are
+    placed In close proximity to diseased
+    animals, the disease makes much less
+    rapid progress under sanitary conditions when the animals are so placed.
+    If our readers who are keeping
+    dairy cows will see that the stables
+    in which they are kept are well lighted and well ventilated it will save
+    them more money than any other investment of a like sum. This disease
+    of tuberculosis is becoming more and
+    more dangerous every year, not merely to the cattle hut still more so to
+    hogs. When the farmer finds that
+    his hogs have been found on inspection to be tuberculous he may know
+    to a dead certainty that his cows are.
+    The sooner he takes our advice and
+    has his cows tested, and then fattens
+    and sells subject to inspection those
+    that react, the better off he will be
+    and the better off his neighbors will
+    be. The man who follows this method
+    is a public benefactor and also incurs
+    the minimum of loss. The man who
+    finds out that his cattle are tuberculous and sells them to a neighbor for
+    breeding purposes forfeits, and should
+    forfeit, the friendship of that neighbor for a long time.
+    The religion you can keep to yourself Is not worth giving away.
+    USING A CREAM   HARVESTER.
+    The Modern Way of Making Profit
+    On Cows With Little Labor.
+    The arguments in favor of a cream
+    harvester or separator when stated
+    within reason are perfectly legitimate. They all resolve themselves
+    finally into the one great consideration
+    of greater profit from the cows. It is
+    not disputed that more cream can be
+    gathered from the milk with a cream
+    separator than by the old way. It
+    therefore avoids waste. Less labor
+    is required, because you can make
+    skimming and milking practically one
+    job. Everything is completed morning and evening, and you are off to
+    market with the cream and the milk
+    is ready for the calves and pigs. This
+    skimmed milk is warm, fresh and
+    sweet, and is a much better feed than
+    when cold and stale, if indeed it is
+    not sour if skimmed by hand when
+    cold. If you market the cream the
+    load is much lighter than if you haul
+    whole milk to the creamery or the
+    railroad. If you are making butter,
+    it is possible to make a finer article
+    out of separator cream than from
+    hand skimmed cream. You are not
+    bothered with an endless array of pans
+    and crocks, with the never ending jobs
+    of washing, sunning, etc. Finally you
+    can run your dairy with less labor, or
+    you can keep a greater number of
+    cows with the same labor.
+    These are the plain arguments In
+    favor of using a cream separator. As
+    we have said, they all tend directly
+    toward the matter of profit. It is
+    the modern way. The man who expects to make any real profit out of
+    his own light by not falling into line
+    and availing himself of the helps
+    which his neighbors are using.
+    All over the country two excellent
+    cream harvesters are being offered
+    to dairymen by the well known local
+    agents of the International Harvester
+    Company of America. They are known
+    as the Bluebell, a gear drive machine;
+    and the Dairymaid, a chain drive machine. Both machines are simple,
+    easji running easy to clean, and are
+    close skimmers. They have the same
+    high reputation that all other machines
+    manufactured by the International
+    Harvester Company of AmeriGa have.
+    You have the advantages of dealing
+    direct with local dealers. You know
+    that your machine must prove satisfactory. A cream harvester is a good
+    thing to have, and the responsible
+    local dealer in your own town with
+    whom you are personally acquainted
+    is a very good man to deal with when
+    you go to buy.
+    For caked udder use lard with a lit
+    tie turpentine and rub well into the
+    hard spots after each milking and
+    the cake will soon disappear.
+    Lakeside Stock
+    Farm
+    The handsomest herd of the breed and of
+    very high production—125 on hand.
+    Ten cows last year, a majority being 1, 2
+    and 3 years heifers, made A. R. O. records
+    which averaged over 20 lbs. in 7 days.
+    21 cows, over 75 per cent being heifers, included the whole number tested, averaged
+    over 17% lbs. A. K. O.
+    8 prizes offered by the Holstein-Friesian
+    Association for Butter Kecords awarded to
+    cows in this herd.
+    Low Prices
+    Cows, Heifers, Calves—all of high quality
+    and breeding—including one bull in whose
+    pedigree are 20 dams with butter records
+    which average over 26% lbs. in 7 days.
+    Is there any bull in the world that can surpass this?
+    Write for particulars.
+    E. A. POWELL
+    Syracuse, New York.
+    BULLS AND HEIFERS
+    Holstein Calves For Sale now, sired by Sir
+    Korndyke Mercedes who has ten dams in his
+    pedigree with official records averaging over
+    25.3 lbs. butter in 7 days. Write for descriptions and prices.
+    ELMWOOD FARM
+    U. L. Lashbrook.
+    NORTHFIELD, MINN.
+    Home Farm Holstein
+    FRIESIANS
+    Our females are mostly sired by Jewel of Home
+    Farm, tbe champion show bull of the breed and
+    Colantha 4th's Lad whose three nearest dams av
+    erage over 25 lbs. butter in seven days.
+    A few fine cows and heifers and some young
+    bulls of serviceable age at reduced figures to make
+    room.   W. B. BARNEY & CO., Hampton, Iowa
+    FAIRVIEW STOCK FARM
+    GEORGE L. MILLER, Prop.
+    I have a few Choice BULL OALVES from
+    our best Holstein-Friesian Oows Por Sale.
+    I  mile from  Northfleld,  /Vllnn.
+    SILO
+    THE
+    MINNEAPOLIS
+    AIR TIGHT
+    The Panel
+    construction is stron g e r
+    than staves, tighter and will
+    not shrink.
+    Prof. Haecker of University Minn., Dairy School,
+    says: "The Silo you built
+    for us has given entire satisfaction. Material is excellent quality, construction good. Ensilage was
+    preserved perfectly.
+    write Free Booklet
+    Puffer-Hubbard Mfg. Co SSSHSS!
+    Minneanolis. Minn. **At.W.'.'{£&
+    RAISE CALVES WITHOUT MILK
+    Our BOOKLET plnlnly tells the story of
+    Blatchford's Calf Heal with convincing testimonials
+    from some of the 20.000 progressive farmers who
+    have had wonderful results from this perfect
+    milk substitute. Writftfor booklet-it's FREE.
+    Blakhford'j Calf Meal Factory *" Waukeean. 111.
+  transl: {}
+  fullrs: Volume13/umn251081.tif
+  find: 564.jp2
+  dmaccess: {}
+  dmimage: {}
+  dmcreated: '2014-02-13'
+  dmmodified: '2014-02-13'
+  dmoclcno: {}
+  dmrecord: '792'
+  restrictionCode: '1'
+  cdmfilesize: '990851'
+  cdmfilesizeformatted: 0.94 MB
+  cdmprintpdf: '0'
+  cdmhasocr: '1'
+  cdmisnewspaper: '0'
+  page: []
+  id: nfh/792
+- pagetitle: Page 6
+  pagefile: 565.jp2
+  pageptr: '793'
+  title: Page 6
+  photog: {}
+  contri: {}
+  descri: {}
+  dat: {}
+  publia: {}
+  dimens: {}
+  genera: {}
+  type: {}
+  physic: {}
+  specif: {}
+  subjec: {}
+  city: {}
+  county: {}
+  state: {}
+  countr: {}
+  geogra: {}
+  geonam: {}
+  langua: {}
+  par: {}
+  contra: {}
+  contac: {}
+  rightc: {}
+  rights: {}
+  rightd: {}
+  public: {}
+  identi: {}
+  resour: umn251082
+  audio: {}
+  audioa: {}
+  video: {}
+  projec: {}
+  fiscal: {}
+  publis: University of Minnesota
+  date: 7/19/2013 15:12
+  format: image/jp2
+  digspe: image/tiff
+  digspa: '29523140'
+  digspb: '24'
+  digspc: '300'
+  digspd: none
+  digspf: '2757'
+  digspg: '3566'
+  digsph: i2s CopiBook
+  digspi: Adobe Photoshop CS
+  digspj: Windows XP
+  digspk: 0aac3d99f93feba6ea33af49730b5d97
+  transc: |-
+    HEATWOLE'S DAIRY PAPER
+    LOCAL   CREAMERY    PROSPEROUS
+    Report cf Todd County Creamery for
+    October  Shows  Success.
+    The October report of the Todd
+    county creamery at this place was
+    handed us this week and on looking
+    over the report given herewith it will
+    he noticed that this institution did a
+    nice business during last month and
+    is keeping up its wonderful record.
+    The association has paid an annual
+    dividend of 32 per cent for the past
+    two years and the prospects are that
+    it will continue to do so. The creamery building is being painted and fixed up and there is a look of prosperity
+    about the grounds.
+    Following is the report for October:
+    Pounds   milk  received    337,034
+    Pounds  cream  received        6,005
+    Average test of milk          4.20
+    Average test of cream       2.6
+    Pounds  butterfat  from  milk.. .14185.4
+    Pounds butterfat from cream..  1723.3
+    Pounds butter made     20,223
+    Pounds  butter sold  to  patrons       819
+    Pounds  butter shipped      18,491
+    Pounds   butter   sold   elsewhere      913
+    Price  paid for butterfat        $0.30
+    Receipts   from   butter 5303.26
+    Receipts  from  other  sources. .    10.10
+    Paid patrons        4772.66
+    Runing expenses      340.56
+    Sinking  fund     190.04
+    Below is the list of patrons who received a check for more than fifty dollars for the month:
+    Theo.  Gaulke        $75.33
+    John   Siegle          88.64
+    Henry Gerlach         67.29
+    Louis Gothmann       63.66
+    August Tesch   '...      61.71
+    .Tohn   G'Meiner          59.79
+    George Eberle       58.60
+    E. H. Bemis       56.Xo
+    Ernest   Koester           55.86
+    William Koester          52.32
+    John   Heinck          51.93
+    George   Lano          51.43
+    Carl   Tesch          51.27
+    —Todd County Argus.
+    November Oleo Output.
+    There was an apparent decrease in
+    the output of oleomargarine in the
+    Chicago district for the month of
+    November, but if it were possible
+    to get at the actual sales it is doubtful that the same situation would be
+    shown. The Internal Revenue Department reports only the amount of
+    stamps sold for that purpose and it Is
+    prohable that the oleo manufacturers
+    purchased more stamps during October than were needed for that month's
+    use. At any rate the reports just received from Chicago give the output
+    for November as 3,910,448 lbs. of uncolored, on which a tax of %c per
+    pound was paid, and 373,511 lbs, of colored which carried a tax of 10c. This
+    makes the total 4,283.959 lbs.
+    THE LEADER
+    Litter
+    Carrier
+    B
+    EFORE long
+    every farmer
+    will be in the
+    market for a good
+    feed and litter carrier
+    and when they get
+    one they want the
+    best. I have examined them all and have
+    built one to remedy
+    all defects.    In
+    The LEADER
+    I have one that is
+    durable and one that
+    is made for service
+    and not merely show.
+    Write me for prices
+    on tracking and fitting your barn.
+    IVI. C. SHUMWAY, Farmington, Minn.
+    Poorly Attended Meeting..
+    The meeting of the Minnesota Dairymen's Association, at the opera house,
+    in this city Tuesday, of the present
+    week, was not as well attended as it
+    should have been. The gentlemen who
+    promised to be here and make addresses were here and they all gave the audience good plain, practical, common
+    sense talks. The one thing which they
+    all sought to impress upon tbe minds
+    of the audience was the importance
+    of the dairy interests of this State,
+    what it means not only as a means of
+    revenue to the farmers of the State,
+    but what it means as one of the great
+    industries of the State. From what
+    was said and vouched for as facts as
+    to the profits there is to the farmers in
+    the co-operative creamery it is a matter of profoundest surprise that a
+    creamery at Madison or anywhere else
+    in this State should stand idle. Show
+    a business man where his business
+    could be strengthened and the net
+    results increased and within twenty-
+    four hours he will have the field well
+    in hand and be reaping the benefit.
+    This creamery business needs the
+    same energy, nerve and application
+    as any other business, and when they
+    are applied, results will follow far in
+    excess of what can be attained from
+    the same amount of capital the farm
+    er can invest in any other branch of
+    his business, or those gentlemen who
+    have made the matter the study of a
+    lifetime did not know what they were
+    talking about last Tuesday—and we
+    all believe they did know and were
+    giving plain statements of facts in everything they said. What the creamery at Madison needs is less talk
+    and some good, hard work.— Madison Independent-Press.
+    Who Owns the Forests.
+    At present only about 22 per cent
+    of our total forest area is in State or
+    national forests, assuming a forest area
+    of 700,000,000 acres, the remainder
+    being on unreserved public lands or in
+    private hands. This condition is represented graphically in figure 8. The
+    forest area of the United States is
+    amply sufficient, if rightly managed,
+    to produce eventually enough timber
+    to supply all our needs. Yet private
+    owners as well as the State and National governments, must use their
+    forest lands in a right way if we are
+    to maintain our timber supply.
+    Weeds on the western farms will
+    soon demand that more sheep be kept.
+    Every dairy farmer should have a
+    flock. Start with a few and you will
+    soon grow to like them so well that
+    you would not be without them.
+  transl: {}
+  fullrs: Volume13/umn251082.tif
+  find: 565.jp2
+  dmaccess: {}
+  dmimage: {}
+  dmcreated: '2014-02-13'
+  dmmodified: '2014-02-13'
+  dmoclcno: {}
+  dmrecord: '793'
+  restrictionCode: '1'
+  cdmfilesize: '1270432'
+  cdmfilesizeformatted: 1.21 MB
+  cdmprintpdf: '0'
+  cdmhasocr: '1'
+  cdmisnewspaper: '0'
+  page: []
+  id: nfh/793
+- pagetitle: Page 7
+  pagefile: 566.jp2
+  pageptr: '794'
+  title: Page 7
+  photog: {}
+  contri: {}
+  descri: {}
+  dat: {}
+  publia: {}
+  dimens: {}
+  genera: {}
+  type: {}
+  physic: {}
+  specif: {}
+  subjec: {}
+  city: {}
+  county: {}
+  state: {}
+  countr: {}
+  geogra: {}
+  geonam: {}
+  langua: {}
+  par: {}
+  contra: {}
+  contac: {}
+  rightc: {}
+  rights: {}
+  rightd: {}
+  public: {}
+  identi: {}
+  resour: umn251083
+  audio: {}
+  audioa: {}
+  video: {}
+  projec: {}
+  fiscal: {}
+  publis: University of Minnesota
+  date: 7/19/2013 15:12
+  format: image/jp2
+  digspe: image/tiff
+  digspa: '28051162'
+  digspb: '24'
+  digspc: '300'
+  digspd: none
+  digspf: '2629'
+  digspg: '3553'
+  digsph: i2s CopiBook
+  digspi: Adobe Photoshop CS
+  digspj: Windows XP
+  digspk: 90672f6c792fc400a265bbbdb8f9e090
+  transc: |-
+    HEATWOLE'S DAIRY PAPER
+    AGRICULTURAL   ANNUAL.
+    Secretary Wilson Sends Out the Advance Sheet of His Report.
+    The advance sheets of the report of
+    Secretary of Agriculture James Wilson, for the year 1907, have been received and that part of it dealing with
+    the dairy industry is particularly interesting at this time.
+    In speaking of the value of farm
+    products it says. "There were farm
+    dairy products in 1907 which nearly
+    reached $800,000,000. The price of
+    butter increased 4%c per pound over
+    the year 1906 and milk %c per gallon."
+    Continuing the report says: "Dairy
+    products are much more valuable than
+    any crop except corn and are equal
+    to one-third of the value of all cereals."
+    It would seem that the secretary,
+    having this knowledge of the value of
+    the dairy products of the United
+    States, would see to it that an industry that means so much to the people
+    is enttiled to greater recognition at
+    the hands of his department than it
+    has yet received.
+    While it is true that he has given
+    us the best administration of the affairs of his office that the country has
+    ever had, and he has done more for
+    the dairy interest than all his predecessors put together, yet the magnitude of the industry warrants even
+    greater attention than he has seen fit
+    to give it. The dairy division of the
+    agricultural department is entitled to
+    a separate bureau by itself at least;
+    and it would seem that if its wealth
+    producing possibilities were taken into consideration, another cabinet office created for it would not be asking more than it merits. The report,
+    dealing with the work being done by
+    the department to advance the cause
+    of dairying States: "Investigations
+    to determine the cause of fishy flavors
+    in butter are being continued and
+    progress has been made; but a complete solution has not yet been
+    reached.
+    "Experiments have also been made
+    concerning the amount of acidity in
+    cream and its effect upon the keeping
+    quality of butter. Several thousand
+    pounds of butter were made from
+    cream having various degrees of acidity and the butter was stored at different temperatures to test its keeping qualities. It was found that pasteurized cream, churned sweet without starter, produced remarkably fine
+    butter that kept without deterioration for weeks after it was taken from
+    storage. This was at such marked
+    variance with the general views of
+    buttermakers that it has been deemed
+    best to repeat the experiments during
+    the coming year. If the findings of
+    the past year are confirmed, almost a
+    complete revolution in the methods of
+    making    butter    from    sweet    cream
+    seems likely to occur.
+    "During the year an extremely simple and rapid method of determining
+    the amount of moisture in butter and
+    other products was worked out by the
+    dairy division. Application for patent has been made in such a way that
+    the apparatus and method may be
+    used by any person in the United
+    States without the payment of royalty."
+    Speaking of the station that has
+    been built at Albert Lea, Minn., during the past year the report says:
+    "In the spring of 1907 laboratories for
+    butter and cheese investigations were
+    established at Albert Lea, Minn., in
+    co-operation with the Minnesota experiment station. Bacteriological and
+    chemical laboratories have been
+    built and equipped and arrangements
+    have been made for a large supply ot
+    milk to be used for experimental purposes."
+    Under the head of "Creamery Investigations" we learn: "The economic features of the creamery business
+    have reached special attention during
+    the past year. Reports were solicited from creameries with a view to
+    giving them assistance in their methods of conducting the business. At
+    the close of the year from 500 to 600
+    creameries were reporting monthly. A
+    careful analysis of these reports shows
+    a heavy loss to many creameries and
+    to the farmers supplying them, owing
+    to lax methods and the absence of
+    system in keeping records. These
+    losses are computed to be not less
+    than $5,000,000 a year for the entire
+    country.
+    "Whenever reports indicating defective work are received letters are written pointing out the defects and suggesting remedies.
+    "The market inspection of butter
+    at Chicago and New York has been
+    continued with a view to assisting
+    creameries to improve the quality of
+    their product. Large quantities of butter deficient in quality or found in
+    these markets. When requested by
+    the shipper the experts of the dairy division examine a shipment on its arrival at market and send to him
+    promptly a reliable report as to its
+    condition and quality. If the butter
+    is not of good quality they state what
+    the defects are and make suggestions
+    for overcoming them. This work has
+    resulted in a general improvement
+    in the quality of the butter received
+    on the markets and has thus enabled
+    the creameries to obtain better
+    prices."
+    The above is among some of the
+    most important things in relation to
+    the dairy industry that the report
+    deals with; but it is filled full of
+    interesting and important matter relating to all phases of agriculture, and
+    will well repay anyone who is interested to read it from beginning to end.
+    Warraht.tl to Glv. Satisfaction.
+    Gomhault's
+    Caustic Balsam
+    Has Imitators But No Competitors.
+    A Safe, Speedy and Positive Cure for
+    Curb, Splint. Sweeny, Capped Hock,
+    Strainea Tcndcns, Founder, Wind
+    Puffs, and all lameness from Spavin,
+    Ringbone and other bony tumors.
+    Cures all skin diseases or "Parasites,
+    Thrush, Diphtheria. Removes all
+    Bunches from Horses or Cattle.
+    As a Human Remedy for Rheumatism,
+    Sprains, Sore Throat, etc., it in invaluable-.
+    ^Every bottle of Caustio Balsam Bold is
+    warranted to pive satlstuetion. Price $1 60
+    per bottle. Sold by druggists, or sent by 'express, charpros paid, witn. full directions for
+    its use. fi39~Send for descriptive circulars,
+    testimonials, etc.   Address
+    The Lawrence-Williams Co., Cleveland, 0.
+    HARD MILKING COWS
+    "Hard milking" occurs from varied causes
+    Sometimes the trouble is due to an unnatural
+    construction of the entire length of the canal
+    of the teat, sometimes to new growths along
+    its course, not unfrequently to little shot
+    like bodies attached'to a pedicle, which drop
+    into the canal from above snd form a sort of
+    ball valve obstruction, and again from injuries received without and occasionally due
+    to warty growths at the opening of the teat.
+    The firm of Geo. P. Pilling & Son o., Arch-
+    St., Philadelphia, Pa., have again made the
+    dairy world their debtor by placing on the
+    market a set of instruments designed to remedy such hard milking cows.
+    ^-..■■■■-i .--=<£>.-
+    ,VOJ*«.W>>RD MILKER 0UTFl^W
+    By the use of these simple instruments any
+    intelligent dairyman can often make a comparatively worthless cow into a good one
+    and they are always at hand when an emer
+    gency calls for their use Like all the goods
+    of this house they are safe, sure and "easy
+    to use"
+    The Pilling Hard Milker set consists of,
+    Teat bistoury-slitter, teat opener, milk tube:
+    teat expander and teat soap, all packed in
+    neat case.
+    Full directions are furnished with the in
+    strumenis, and the purchaser is always fre-
+    to consult the staff of Veterinarians employ
+    ed'by the Messers Pilling, regarding all his
+    stock troubles.
+    This house is we believe, the first to go to
+    the expense of a veterinary staff for the free
+    service of their clients,
+    Ask them for circular of the Hard Milker
+    Set—Do it now.
+    sssssssssHssssWpMIsMMssI
+  transl: {}
+  fullrs: Volume13/umn251083.tif
+  find: 566.jp2
+  dmaccess: {}
+  dmimage: {}
+  dmcreated: '2014-02-13'
+  dmmodified: '2014-02-13'
+  dmoclcno: {}
+  dmrecord: '794'
+  restrictionCode: '1'
+  cdmfilesize: '1000040'
+  cdmfilesizeformatted: 0.95 MB
+  cdmprintpdf: '0'
+  cdmhasocr: '1'
+  cdmisnewspaper: '0'
+  page: []
+  id: nfh/794
+- pagetitle: Page 8
+  pagefile: 567.jp2
+  pageptr: '795'
+  title: Page 8
+  photog: {}
+  contri: {}
+  descri: {}
+  dat: {}
+  publia: {}
+  dimens: {}
+  genera: {}
+  type: {}
+  physic: {}
+  specif: {}
+  subjec: {}
+  city: {}
+  county: {}
+  state: {}
+  countr: {}
+  geogra: {}
+  geonam: {}
+  langua: {}
+  par: {}
+  contra: {}
+  contac: {}
+  rightc: {}
+  rights: {}
+  rightd: {}
+  public: {}
+  identi: {}
+  resour: umn251084
+  audio: {}
+  audioa: {}
+  video: {}
+  projec: {}
+  fiscal: {}
+  publis: University of Minnesota
+  date: 7/19/2013 15:12
+  format: image/jp2
+  digspe: image/tiff
+  digspa: '29523140'
+  digspb: '24'
+  digspc: '300'
+  digspd: none
+  digspf: '2757'
+  digspg: '3566'
+  digsph: i2s CopiBook
+  digspi: Adobe Photoshop CS
+  digspj: Windows XP
+  digspk: 9a222b654f0857c140f4943e4596757b
+  transc: |-
+    n^nsmmnmnR
+    m
+    HEATWOLE'S DAIRY PAPER
+    HEATWOLE'S DAIRY PAPER
+    Published on the first of each month at
+    Northfleld, Minnesota.
+    BY JOEL, P   HEATWOLE.
+    W.  F.  SCHILLING, EDITOR.
+    Subscription  Rates:
+    Single copy, 25 cents a year; three years,
+    50 cents.   This paper is sent only to paid-
+    in-advance subscribers and Is discontinued at date of expiration.
+    Heatwole's Dairy Paper is published in
+    the interests of the dairymen and farmers
+    of the Northwest.
+    Entered as second-class matter April 25, 1906, at
+    the post office at Northfield, Minn., under act
+    of Congress of March 3  1879.
+    BREAD AND BUTTER STATE.
+    Twenty years ago comparatively few
+    people thought of Minnesota, as a
+    dairy State. They had only begun
+    then, and that In the older settlements,
+    to practice diversified farming, and
+    the causes which led to that were regarded as calamitous. Disheartening
+    crop failures and swarms of insect
+    fests were accompanied by a deterioration in the quality of the grain, the
+    result of continuous cropping.   But
+    'Ills of every shape and every name.
+    Transformed to blessings, miss their
+    cruel aim"
+    under the direction of an overruling
+    Providence. The failure of wheat cultivation proved ultimately the best
+    thing that could have happened. The
+    farmers forced to give us their dependence on a single crop began to
+    experiment and the experiment which
+    on the whole was proved the most
+    satisfactory and the most profitable
+    has been that of raising cattle and
+    dairying. It is not only because it
+    is in itself profitable. It makes other
+    branches of farming industry more
+    profitable. The maintenance of a dairy
+    herd enables the farmer to return to
+    the soil much that is taken from it
+    in the form of crops. Because a man
+    has a good herd of cattle he can raise
+    hogs and poultry more profitably. The
+    necessity of providing fodder at all
+    times for the cattle compelled farmers to give greater attention to the
+    cultivation of corn which has taken
+    the place of wheat as the .surest and
+    most profitable of crops. It encouraged the seeding of lands to clover
+    and other forage crops as a means of
+    giving new life to worn out soils. It
+    was followed by the establishment of
+    creameries in due time. The bringing of the butter made at these creameries into competition with that made
+    in other States has demonstrated that
+    whether through accident or design
+    the farmers of Minnesota had engaged
+    in that industry to which the soil is
+    best adopted. Much as the State owes
+    to the capacity, the industry and the
+    intelligence of its buttermakers, that
+    does not altogether account for the
+    superiority of Minnesota butter as
+    demonstrated again and again in national contests. There must be many
+    men as competent as they are in Iowa,
+    in Michigan, in Indiana, in New York
+    in Ohio and elsewhere. But nowhere
+    else than in the great State of
+    in Minnesota can be found exactly
+    that combination of succulent grasses and other natural food products
+    best adopted to the feeding of dairy
+    cattle. Minnesota is par excellence
+    the dairy State not because of acquired knowledge but because of natural
+    gifts.
+    At first it was thought that the dairy
+    industry would be confined to Southern Minnesota. We are learning better. At the last annual meeting of the
+    Dairymen's association, in one of the
+    most interesting papers read, a young
+    dairyman told how, in the home of
+    No. 1 hard wheat he had been able to
+    lift a mortgage of $4,000 incurred in
+    attempting to make money from the
+    favorite crop of that section, by forsaking the old methods and taking up
+    dairying. All over that fertile valley
+    men are today looking to dairying as
+    the industry of the future. It wasn't
+    so long ago that people though they
+    saw hope for the cut-over pine district
+    between St. Paul and Duluth as a
+    region specially adopted to the raising of potatoes. They too have learned better. It has been found that in
+    those sandy soils not only do taters
+    yield abundantly, but that nowhere
+    else in the State can such crops of
+    timothy and clover be grown and
+    wherever there is clover and timothy
+    there are other grasses to combine
+    with them to make good grazing.
+    Those familiar with the country are
+    strong in the conviction that here is
+    a great future for cut over pine lands
+    as the seat of a dairy industry. So
+    that dairying can no longer be regarded as confined to the southern
+    counties. It is making way everywhere. In every section, except perhaps in the extreme north, it is certain in a future which is not very far
+    distant to add materially to the wealth
+    and the resources of the agricultural
+    population.
+    Not the least of the advantages of
+    the growth of the dairy industry has
+    been the encouragement of co-operation among the farmers. To produce
+    the best results they have found it
+    necessary to work together. Thus
+    they have built their own creameries
+    and secured for themselves, in some
+    counties almost exclusively, the profits which would otherwise have gone
+    to middlemen. The dairymen have
+    transacted their own business. The
+    co-operative creamery has had an educational value it Is hard to overestimate. It has a social value too,
+    and   through   it  men   have   come   to
+    know each other better and to be better qualified to take an intelligent part
+    in business and in public affairs.
+    The advantage of all this is being
+    felt more and more in every part of
+    the State. The dairy industry has
+    come to be regarded as one of 'he
+    most important of the resources of
+    the State. Creamery products are not
+    only more a dependence as a source
+    of income than the crops, the price not
+    generally being subject to great fluctuations, but they bring ready money
+    to the community every month in the
+    year. The old days when the farmer
+    had either to deprive himself and his
+    family of many comforts or else go
+    in debt awaiting the season for his
+    crops to ripen ire gone by. If he
+    takes advantage of his opportunities,
+    he has always a source of income
+    which he can depend upon with absolute certainity. As upon the welfare
+    of the farmer is founded the welfare
+    of the State, as upon his prosperity
+    depends the prosperity of every class
+    in the community, it is of no small advantage to Minnesota that it is no
+    longer merely the world's bread
+    basket but has evolved into the "Bread
+    and Butter State."
+    BETTER   USE GRADES.
+    In the breeding of pure bred cattle one finds that there are a great
+    many kinds of people in the world and
+    after he has been in the business for
+    a few years he begins to find that it
+    is the fellow who changes his politics
+    every presidential election who is repeatedly changing breeds of cattle and
+    his cheapness in politics also is noticeable in his selection of cattle. You
+    can mark him before he gets to the
+    farm for he usually writes a few letters asking the price on the best animals in the herd and after he has worn
+    out his subject on paper he comes to
+    the breeder and wants to see the cows
+    that he has priced and his correspondence has been so voluminous that he
+    imagines that he is the only one who
+    is after cattle and he goes over his
+    story and repeats everything he" has
+    said and when shown the cattle he
+    wants the best in the herd and he
+    wants them at a price just one third
+    lower than is asked for the most inferior animal in the herd. He lingers
+    around and if he buys at all he ends
+    by taking the poorest animal he can
+    find and takes it home and tells all
+    the neighbors of the great purchase
+    he has made and the neighbors wait
+    to see him change again in a year
+    or more and make a failure out of
+    the next breed he tries.
+    Such men are a detriment to the
+    cattle business and breeding business
+    in general and they had better invest
+    their money in grades than to tackle
+    a business that they know nothing
+    about and are too obstinate to learn.
+  transl: {}
+  fullrs: Volume13/umn251084.tif
+  find: 567.jp2
+  dmaccess: {}
+  dmimage: {}
+  dmcreated: '2014-02-13'
+  dmmodified: '2014-02-13'
+  dmoclcno: {}
+  dmrecord: '795'
+  restrictionCode: '1'
+  cdmfilesize: '1353163'
+  cdmfilesizeformatted: 1.29 MB
+  cdmprintpdf: '0'
+  cdmhasocr: '1'
+  cdmisnewspaper: '0'
+  page: []
+  id: nfh/795
+- pagetitle: Page 9
+  pagefile: 568.jp2
+  pageptr: '796'
+  title: Page 9
+  photog: {}
+  contri: {}
+  descri: {}
+  dat: {}
+  publia: {}
+  dimens: {}
+  genera: {}
+  type: {}
+  physic: {}
+  specif: {}
+  subjec: {}
+  city: {}
+  county: {}
+  state: {}
+  countr: {}
+  geogra: {}
+  geonam: {}
+  langua: {}
+  par: {}
+  contra: {}
+  contac: {}
+  rightc: {}
+  rights: {}
+  rightd: {}
+  public: {}
+  identi: {}
+  resour: umn251085
+  audio: {}
+  audioa: {}
+  video: {}
+  projec: {}
+  fiscal: {}
+  publis: University of Minnesota
+  date: 7/19/2013 15:12
+  format: image/jp2
+  digspe: image/tiff
+  digspa: '28051162'
+  digspb: '24'
+  digspc: '300'
+  digspd: none
+  digspf: '2629'
+  digspg: '3553'
+  digsph: i2s CopiBook
+  digspi: Adobe Photoshop CS
+  digspj: Windows XP
+  digspk: 240329b4c9aa38b2b587300caf000e2a
+  transc: |-
+    HEATWOLE'S DAIRY PAPER
+    9
+    What a contrast the fellow pictured above it with the man who comes
+    into a breeders herd and says, "I want
+    a few animals of the very best breeding you have and I want to make a
+    foundation for a herd of pure bred
+    cattle." The former never succeeds
+    and the latter invariably does.
+    pie of the State is being faithfully and
+    intelligently carried out.
+    FAIR MANAGEMENT.
+    It is not unlikely that at the next
+    meeting of the Minnesota legislature
+    steps will be taken to re-organize the
+    management of the State fair, and to
+    provide for its affairs that supervision
+    which circumstances indicate to be
+    necessary. The revenues of the fair
+    are now so large and it has developed
+    into so important a State institution
+    that it is due to the people that adequate and efficient machinery be provided for the conduct of its affairs.
+    The fair is presumably designed to
+    recognize  and  to  encourage  the   industries  of the  State,  and to be an
+    exposition of them.   Whether it fully
+    serves that purpose, whether the proportion of its revenues devoted to it
+    is as large as it should be, whether
+    sufficient encouragement is   given  to
+    the farmers and the farming communities  to  make  exhibits,  whether  the
+    money paid in premiums outside of the
+    State is Justified by the  educational
+    value to the agricultural  population,
+    whether the fair is too great an extent made a sporting carnival for the
+    benefit  of  amusement  lovers  of the
+    twin cities, whether all are accorded
+    equal privileges and required to make
+    equal   contributions   towards   its   revenues, whether there are or are not
+    people who because of their intimate
+    relations with the officers of the board
+    are granted special favors—all these
+    are questions in which the people of
+    the State are interested and on which
+    they   should   have  full  information.
+    When   the  fair's  management  is  responsible to no one this information
+    is at present unattainable.    It is not
+    ment to intimate here that there is
+    anything wrong with  the  State  fair
+    management, or that the men connected with it are not entirely unselfish
+    and   are  exerting  themselves   purely
+    for the benefit of the public.   But the
+    situation is one men could easily take
+    advantage of, and our plea is for responsible fair    management, a much
+    wider publicity of its affairs, and that
+    official supervision of them which the
+    public has  a right to  demand.    The
+    people want not merely a successful
+    fair where they can be entertained for
+    a few days in the year if they pay the
+    price.    Private  enterprise  could  furnish that.    They want even more, to
+    know that a great public institution is
+    used to serve private ends but that the
+    purpose for which it was designed of
+    encouraging and being a faithful exposition of the industries of the peo-
+    GREETING TO NEW READERS.
+    This issue of Heatwole's Dairy Paper will go into the hands of hundreds
+    of new readers this month and it is to
+    be hoped that some of these new
+    readers will be added to the regular
+    list and that they will want to have
+    it a regular monthly visitor In the
+    future. The paper is young yet and
+    was not started with the idea that
+    it was to be the only dairy paper in
+    existence hut to fill a vacancy in the
+    northwest. There is always a demand
+    in the great northwest for good dairy
+    literature and it is hoped that those
+    who receive this number will feel
+    that there is room for a paper of its
+    size and general make-up at the extremely low price of only FIFTY
+    CENTS FOR THREE YEARS. The
+    paper is sent to only those who sud-
+    scribe for it and it is always discontinued at the end of the time for
+    which it is paid.
+    The paper is edited by a practical
+    dairy farmer who is actually living
+    on the farm and helps with every
+    branch of the work about the dairy. It
+    will thus be seen that what comes
+    from Heatwole's Dairy Paper must be
+    practical and worthy of the consideration of its readers. The paper only
+    comes once a month and for this reason the busy farmer always has time
+    to look at it. If you are not now a
+    subscriber send at once fifty cents
+    either in two cent stamps or postal
+    order and you will receive the paper
+    for the next three years.
+    cows in his herd that are high up on
+    legs and believes that his animals of
+    the future should be nearer the ground
+    he should see to it that the sire he
+    selects is one of the low down type
+    , and one that will he more of the
+    I type he desires to breed. He should
+    ! look well to the vigor and constitution of the animal and see that he
+    gets; one that will get good strong
+    offspring.
+    When the right animal is found
+    there is no such a thing as paying
+    too much for him. Nine out of ten
+    good hulls are sold too cheap. How
+    often do those who are breeding care
+    to pay over twice as much for a sire
+    as a cow and yet they expect to have
+    this sire better the condition of the
+    herd for the next three or four or even
+    five years to come. Keep only the
+    best sire possible to head your herd
+    and then gradually get rid of the
+    poorer cows and keep fewer and better animals and your profits will be
+    very materially increased.
+    THE PRICE OF A GOOD DAIRY SIRE
+    At this season of the year nearly
+    every good dairyman is looking to
+    find a good sire to head his herd and
+    if they would all look to quality instead of to price there would not be
+    one-half enough good bulls to go
+    around. There is by far too little
+    thinking done by the average man
+    who purchases a sire to head his
+    herd. There is but one qualification
+    looked at by many and that is that
+    he must be a full blood and when
+    they have this they are of the opinion
+    that they have it all in a nutshell when
+    the fact of the matter is that they
+    have only begun to think about the
+    breeding business and that they are
+    too often going backwards. We do
+    not wish to be understood as saying
+    that a pure bred sire is not better
+    than the scrub for he is. But there
+    is a vast difference In pure bred sires
+    and there are points that should be
+    looked into and considered thoroughly before the purchase is made. There
+    is the matter of type. Every breeder
+    should have a type of animal that is
+    his ideal and he should choose a sire
+    with the end in view to perpetuate
+    that type.    If he has  a number of
+    THE NORTHFIELD CONVENTION.
+    The Minnesota State Dairymen's association will hold its thirtieth annual
+    convention    at   Northfleld,    Tuesday,
+    Wednesday and Thursday, Jan. 21, 22
+    and 23, 1908.   The membership as well
+    as interest in this association is growing every year.    The dairy Industry
+    in Minnesota is also growing year by
+    year, the output    of   the    Minnesota
+    creameries has now passed  the one
+    hundred million mark In pounds, and
+    the cash income to the farmers is upward of fifteen million dollars, and yet
+    we   are   as   dairymen   not   producing
+    more   than   two-thirds   of   what   we
+    should from the number of cows kept.
+    Every dairyman should  attend the
+    Northfield convention and hear talks
+    from the best authorities on feeding,
+    breeding, how to organize a cow testing     association;     the     co-operative
+    creamery   vs.   the   centralizer,   both
+    sides  will be  argued;   report of  the
+    committee on co-operative selling and
+    what has been done, and many other
+    good things—you cannot afford to miss
+    it.   A butter and cheese scoring contest will he an important feature of the
+    convention.    Butter will be in three
+    classes,  whole  milk  creamery,  hand
+    separator creamery and dairy butter;
+    cheese, American full cream, brick and
+    Switzer. Liberal premiums will be given.   The only entry fee for this contest  is  a  membership   costing  $1.00,
+    proceeds from    sale    of butter    and
+    cheese will be returned to owner less
+    freight.
+    Don't forget the dates and don't
+    forget to come. Northfleld will give
+    us a royal entertainment for they
+    know how to do things there and th6
+    parties who have charge of arrangements, have guaranteed us the best
+    time we ever had. Everybody will be
+    taken care of. —Secretary.
+    ..;,.■■•.:-;:.:-  ■    ■:':■'■■'■ ■■■'■ '•'■'*  :'
+  transl: {}
+  fullrs: Volume13/umn251085.tif
+  find: 568.jp2
+  dmaccess: {}
+  dmimage: {}
+  dmcreated: '2014-02-13'
+  dmmodified: '2014-02-13'
+  dmoclcno: {}
+  dmrecord: '796'
+  restrictionCode: '1'
+  cdmfilesize: '1032022'
+  cdmfilesizeformatted: 0.98 MB
+  cdmprintpdf: '0'
+  cdmhasocr: '1'
+  cdmisnewspaper: '0'
+  page: []
+  id: nfh/796
+- pagetitle: Page 10
+  pagefile: 569.jp2
+  pageptr: '797'
+  title: Page 10
+  photog: {}
+  contri: {}
+  descri: {}
+  dat: {}
+  publia: {}
+  dimens: {}
+  genera: {}
+  type: {}
+  physic: {}
+  specif: {}
+  subjec: {}
+  city: {}
+  county: {}
+  state: {}
+  countr: {}
+  geogra: {}
+  geonam: {}
+  langua: {}
+  par: {}
+  contra: {}
+  contac: {}
+  rightc: {}
+  rights: {}
+  rightd: {}
+  public: {}
+  identi: {}
+  resour: umn251086
+  audio: {}
+  audioa: {}
+  video: {}
+  projec: {}
+  fiscal: {}
+  publis: University of Minnesota
+  date: 7/19/2013 15:13
+  format: image/jp2
+  digspe: image/tiff
+  digspa: '29523140'
+  digspb: '24'
+  digspc: '300'
+  digspd: none
+  digspf: '2757'
+  digspg: '3566'
+  digsph: i2s CopiBook
+  digspi: Adobe Photoshop CS
+  digspj: Windows XP
+  digspk: d8230e5f5430bab5211e291d8a1466d0
+  transc: |-
+    mm*
+    10
+    HEATWOLE'S DAIRY PAPER
+    F   I
+    BURNING STRAW STACKS.
+    The west will soon see the time,
+    if it has not already, when the burning of straw stacks must be discontinued if the fertility of the land is
+    to be kept up. It is almost a crime to
+    look over the horizon in the fall of
+    the year and see the numerous fires
+    that indicate to the observer so much
+    wealth gone up in smoke. There are
+    men who seem to go on the assumption that there is no end to the fertility of the soil in this western country; but they will soon realize that
+    there is an end and that end will
+    come too when they are not aware
+    of it and the value of their farms will
+    be reduced fifty per cent and then it
+    will he to borrow money to purchase
+    fertilizer and work for many years
+    to bring it back to the present state of
+    fertility.
+    If the straw stack cannot be made
+    better use of it should be placed in
+    the barn yard where the cattle can
+    run over it and make it into fertilizer.
+    There are some who say that their
+    farms are already too rich, upon which
+    to grow grain, if they are manured
+    with barnyard manure and to those
+    we will say that it is high time that
+    this fertilizer be applied to the corn
+    ground and to the pastures. There
+    is no piece of land that is too fertile
+    to grow good corn and there is a
+    need of a whole lot of fertilizer on
+    the pastures of the west. Do not burn
+    the straw. Better pile it up and let
+    it rot a few years and you will have
+    the fertilizer when you are in need
+    of it.
+    The time is not far distant when
+    you will be calling for more fertility
+    as every time a farmer sells a ton
+    of wheat he sells $11.62 in fertility;
+    in a ton of alfalfa hay, he sells $8.63
+    in fertility; in a ton of oats, he sells
+    $7.81 in fertility, and in a ton of corn
+    he sells $6.47 in fertility. If these products be fed on the farm and the manure and straw returned to the soil
+    there is practically no loss.
+    FEEDING FRESH COWS.
+    Feeding fresh milking cows is a
+    subject that is quite pertinent just at
+    this time of the year when nearly all
+    good dairymen are having an abundance of them. But before we take up
+    the matter of feeding fresh cows it
+    would be well to say a little about
+    feeding the cows before they are
+    fresh. Too many farmers and dairymen go on the assumption that when
+    a cow is dry she needs no grain feed
+    and here is where they are making a
+    big mistake as the cow is then to be
+    fitted for her next milking period. She
+    should be made dry for at the least
+    six weeks and after she is thoroughly
+    dry she should be fed liberally on
+    good  protien feeds    such  as  ground
+    oats, bran, oil meal, etc., so that she
+    may have the strength to go through
+    her period of calving and be in good
+    condition to give a large flow of milk
+    for the following ten months. Some
+    will say that that is a good way to
+    produce milk fever, but if the cow is
+    properly cared for when she comes
+    in there is not the slightest danger
+    of this. When she freshens do not
+    milk her entirely out for two or three
+    days if her udder seems to contain
+    considerable fever. Just take out a
+    little at a time and gradually bring
+    her to her normal flow of milk.
+    When a cow is cared for and fed
+    in the above manner she will in a few
+    days come to her milk in good shapp
+    with but very little feed and the feeder should see to it that his cow does
+    not get too much feed at this time as
+    there is danger of over feeding and
+    if this done she will not do her best
+    this period. Try to keep her milk
+    flow ahead of her feed and when the
+    feed is increased little by little weigh
+    the milk and see that she is making
+    good use of the feed you are giving
+    her. It is an utter impossibility to
+    feed cows intelligently without weighing the milk every milking at least
+    for a month after the cow has freshened for there is no way of telling
+    what she is doing. After the capacity of the cow has been determined
+    it is very easy to feed her.
+    DISTRICT   BREEDERS   MEET.
+    Stock and Plant Breeders of the Third
+    District  Organize  at   Faribault.
+    The breeders of all kinds of livestock in the Third Congressional drs-
+    tarict met at Faribault on Tuesday,
+    the 17th instant and organized an
+    Animal and Plant Breeders association. There was a good attendance
+    by the breeders from the different
+    counties of the district and a very interesting meeting was held. Prof.
+    Boss of the State experimental farm
+    was instrumental in getting the breeders together and before the forming of
+    a permanent organization the following topics were discussed:
+    The Dairy Interests of the Third
+    District—Hon. J. R. Morley, Owatonna.
+    How and Why I Raise Poland China
+    Swine.—O. F. Henkel, Kenyon.
+    Does Sheep Raising Pay.—Hon C.
+    F. Glotfelter, Waterville.
+    What We Can Gain by Organizing.—
+    J. A. Timpane, Waterville.
+    Management of a Milking Herd—W.
+    F. Schilling, Northfield.
+    How Can We Get Better Use from
+    Our Pure Bred Sires.—Prof. A. Boss,
+    St. Anthony Park.
+    After the discussion of the program
+    there was much sentiment in favor of
+    a permanent organization and a constitution and by-laws were drawn up and
+    adopted and the following officers were
+    Warriner's
+    Chain-
+    Hanging
+    Stanchion
+    Prof. R. D- Shaw,
+    of Michigan Agricultural college, writes: "The Warrin-
+    er Stanchions bought ofyou four years
+    ago have given good satisfaction. If it
+    were not so we would not be giving you
+    this second order." Shipped subject
+    to trial in buyer's own barn.
+    W. B. CRUMB.
+    222 Main Si. Forestville, Conn.
+    S60
+    62  PARK sr
+    GOES  LIKE  SIXTY
+    SELLS LIKE SIXTY
+    SELLS FOR SIXTY
+    GASOLINE
+    ENGINES
+    for Pumpingr,
+    CreamSeparator,
+    Churn, Washing Machine,
+    Ice Cream Freezer, etc.
+    [Send for catalogue.
+    GILSON MFG. CO.
+    Port Washington.WIt
+    A REMEDY FOR HEADACHE AND
+    NEURALGIA. A remedy that is simply
+    marvelous in its action. Relieves nervousness. Sleeplessness, h xhaustion. all Head and
+    Nerve Ailments by external use and inhal
+    ing. Harmless and Refreshing. Give it a
+    trial and be convinced of its merits- It is
+    HOYT'S HEADACHE AND NEURALGIA
+    COLOGNE.
+    FOR SALE BY ALL DRUGGISTS.
+    SHIP YOUR
+    HayEzGrain
+    TO
+    Loftus-Hubbard Elevator Co.
+    Geo   F. Loftu, Mgr.
+    ST. PAUL, MINN
+    lAfAAJTEn      REGISTERED
+    Iff AH I EU HOLSTEIN STOCK
+    The Barron County Holstein Breeders'Association is in the market for registered Holsteins, both old and young.    Address
+    F, J. Krahenbuhl, Barron, Wis.
+    1
+    ALL ABOUT HOLSTEINS
+    Send for free illustrated pamphlet describing
+    this great breed of cattle.
+    F.L. HOUGHTON, Sec, BraMleboro, Vt.
+    elected for the ensuing year: President, J. M. Timpane, Waterville; vice
+    president, O. F. Henkel, Kenyon; secretary and treasurer, E. R. Bloomer,
+    Morristown; executive committee, W.
+    F. Schilling, Northfleld, Chas. Crandall,
+    Randolph, Geo. W. Thompson, Faribault, M. C. Hansen, Hutchinson.
+    Although the calf may drink from
+    the pail the first time it is placed before it, it is always best to give it
+    the finger for a time or two as it will
+    then learn to take the milk by sucking
+    it down and will not gulp it down and
+    be troubled with indigestion and later
+    subject to scours.
+  transl: {}
+  fullrs: Volume13/umn251086.tif
+  find: 569.jp2
+  dmaccess: {}
+  dmimage: {}
+  dmcreated: '2014-02-13'
+  dmmodified: '2014-02-13'
+  dmoclcno: {}
+  dmrecord: '797'
+  restrictionCode: '1'
+  cdmfilesize: '1253196'
+  cdmfilesizeformatted: 1.20 MB
+  cdmprintpdf: '0'
+  cdmhasocr: '1'
+  cdmisnewspaper: '0'
+  page: []
+  id: nfh/797
+- pagetitle: Page 11
+  pagefile: 570.jp2
+  pageptr: '798'
+  title: Page 11
+  photog: {}
+  contri: {}
+  descri: {}
+  dat: {}
+  publia: {}
+  dimens: {}
+  genera: {}
+  type: {}
+  physic: {}
+  specif: {}
+  subjec: {}
+  city: {}
+  county: {}
+  state: {}
+  countr: {}
+  geogra: {}
+  geonam: {}
+  langua: {}
+  par: {}
+  contra: {}
+  contac: {}
+  rightc: {}
+  rights: {}
+  rightd: {}
+  public: {}
+  identi: {}
+  resour: umn251087
+  audio: {}
+  audioa: {}
+  video: {}
+  projec: {}
+  fiscal: {}
+  publis: University of Minnesota
+  date: 7/19/2013 15:13
+  format: image/jp2
+  digspe: image/tiff
+  digspa: '28051162'
+  digspb: '24'
+  digspc: '300'
+  digspd: none
+  digspf: '2629'
+  digspg: '3553'
+  digsph: i2s CopiBook
+  digspi: Adobe Photoshop CS
+  digspj: Windows XP
+  digspk: 1902400655b0986a063e5a5fcfc9c2c5
+  transc: |-
+    HEATWOLE'S DAIRY PAPER
+    U
+    SILO   AND   SOFT   CORN.
+    Farmers   who   Built   This   Year   Are
+    Reaping  Harvest.
+    All last summer we urged our
+    readers to provide themselves with a
+    silo, if possible; and we think we can
+    realize the solid satisfaction that those
+    of them who were willing and in shape
+    to take our advice now enjoy, says
+    Wallace's Farmer.
+    In many sections of our territory
+    the corn was injured by frost. Many
+    farmers, anticipating this, put their
+    corn in the silo before it occurred.
+    Others, knowing from reading and experience that even frosted corn made
+    good silage, continued to cut it. The
+    farmer who has plenty of clover hay
+    and plenty of good silage and good
+    cows, with suitable stabling, is not
+    complaining now and will not complain. He will make quite as much
+    money this year as he has ever made
+    from his dairy cows.
+    The farmer who did not have a silo
+    and has frosted corn is now puzzling
+    his brain to know how to feed it to
+    the best advantage. So long as the
+    weather keeps mild and corn does not
+    freeze solid he gets practically all
+    there is in this frosted corn; but
+    when cold weather comes and the soft
+    corn which should have gone to the
+    silo is frozen solid and hence becomes
+    indigestible, he will be dissatisfied
+    with the results, whether it be fed to
+    dairy cows or fattening hogs.
+    The farmer who has a silo will find
+    the work of feeding much more satisfactory during the cold months ot
+    winter than he did when he had to
+    haul corn, the bundles often frozen
+    to the ground, with the snow drifting
+    and the thermometer ten degrees
+    below zero.
+    We speak of this now because we
+    are anxious that next year our readers who are engaged more or less in
+    dairying shall take measures to provide themselves with a silo of some
+    kind and at the same time provide
+    proper shelter for all the live stock
+    to which it is fed. We have not
+    urged our readers who are engaged
+    in feeding cattle, or in keeping stackers through the winter, to provide
+    themselves with silos. We believe
+    they can do so to advantage provided
+    they have proper shelter. The place
+    to begin to use the silo is with the dairy cow, and then feel your way toward feeding it to other kinds of live
+    stock with profit and advantage.
+    Heatwole's Dairy Paper wants to
+    get photographs of the best dairy
+    herds in the country. If you have a
+    good one send it in at once and on the
+    back of the same be sure to write
+    plainly your name and address, the
+    name of the farm, the kind of stock
+    kept and whether pure bred or grades.
+    .=THE WORLD'S GREATEST=
+    HOLSTEIN FRIESIAN CATTLE
+    125 in Herd, Including
+    The  World's Champion, Aaggie Cornucopia Pauline, 34.42 lbs.
+    butter, 4.17 per cent fat in 7 days, as a four year old.
+    The World's Champion DeKol  Creamelle 119.4 lbs. milk in 1 day
+    779 lbs. in 7 days, 3015 lbs. in 30 days.
+    Pietertje Hengerveld's Count DeKol who has more A. R. 0
+    daughters than any bull of his age. including the above World's
+    Champion DeKol Creamelle. We offer exceptional values for foundation stock.
+    Dutchland F^arms
+    D. \A7, anci  F^.  F*.  FIELD
+    18 miles from Boston, Mass., on the New
+    York, New Haven& Hartford Railroad
+    MONTELLO, MASS.
+    {
+    n^ — *,.  ft~. _l._  100,000 % Bbl. Flour Sacks $9.00\J
+    Mdllul    V (501/0   100,000 X Bbl  Flour Sacks 18.00   I
+    mml    Ljnlllln  100,000 % Bbl.Flour Sacks 22.00  -0
+    I    U|JUI    W MW IIV 100,000 X Bbl. Cement Sacks 25.00; §
+    These Sacks are made from Waterproof Paper and replace the Jute Bag:
+    PAPER MILK BOTTLES, $5,00 per 1,000
+    JOS. WERNER, 715 North Park Avenue, Chicago, Illinois
+    CREAM CHECKS ABOVE PAR.
+    To Encourage Patrons They Will Give
+    Premium of 10 Per Cent.
+    That Osakis business men are ever
+    ready to assist in every possible way
+    any enterprise that tends to benefit
+    the village and farming community,
+    and will donate liberally to its maintenance and success, was never better
+    demonstrated than by the action taken this week to encourage the undivided support of the home creamery
+    by dairymen and farmers. This time
+    of year many creameries shut down
+    owing to the light run of cream, but |
+    it is the desire of the Osakis business |
+    men to make the local creameries
+    an all-year-around success, and to
+    that end they have hit upon the
+    unique plan of offering a 10 per cent
+    premium on all cream checks issued
+    by the Osakis creamery. As an illustration, if you have a creamery check
+    issued by Manager N. I. Hugger for $5
+    any of the following business houses
+    of Osakis will honor the check in the
+    sum of $5.50 when presented in exchange for goods: Osakis Hardware
+    Co., A. J. Caugren & Co., E. H. Er-
+    ickson, George Herberger, Wm. Lenz,
+    G. E. Lamphear, C. S. French, J. J.
+    Skuey, Osakis Drug Co.
+    The premium placed on cream
+    checks issued by the Osakis creamery
+    means that the patrons of the local
+    creamery will receive 3c per pound
+    above the New York market price
+    for their cream.   To this may he added
+    the 2c a pound premium received by
+    Mr. Hugger for his entire output of
+    butter, making 5c above normal market price.
+    No Better Exponent.
+    A copy of Heatwole's Dairy Paper
+    has found its way to our exchange
+    table. It is a very creditable production and covers its field in good shape.
+    There is no lack of farm papers in
+    Minnesota and some of them are excellent publications. But we doubt
+    whether a better exponent of the dairy
+    interests of the State can be found
+    than this paper of Mr. Heatwole's.
+    Like everything else that comes from
+    the Northfield News shop it is neat in
+    appearance and thoroughly up to date.
+    —Minneota Mascot.
+    Room for Improvement.
+    Heatwole's Dairy Paper has started
+    a campaign which seeks to make the
+    State fair more of a dairying exhibition than that which it now is—simply
+    an exhibition of fat cattle and used
+    in the interests of the meat trust. The
+    position of the paper is well taken and
+    there is a lot of room for improvement
+    in the distribution of prizes for the
+    dairying industry. It is to be hoped
+    that every paper in the State will use
+    its influence in creating a sentiment
+    along the line that the State Fair association cannot well overlook.—Dassel Anchor.
+    A good many are trying to wash out
+    the slums with teardrops.
+    ■   ' .
+  transl: {}
+  fullrs: Volume13/umn251087.tif
+  find: 570.jp2
+  dmaccess: {}
+  dmimage: {}
+  dmcreated: '2014-02-13'
+  dmmodified: '2014-02-13'
+  dmoclcno: {}
+  dmrecord: '798'
+  restrictionCode: '1'
+  cdmfilesize: '1017268'
+  cdmfilesizeformatted: 0.97 MB
+  cdmprintpdf: '0'
+  cdmhasocr: '1'
+  cdmisnewspaper: '0'
+  page: []
+  id: nfh/798
+- pagetitle: Page 12
+  pagefile: 571.jp2
+  pageptr: '799'
+  title: Page 12
+  photog: {}
+  contri: {}
+  descri: {}
+  dat: {}
+  publia: {}
+  dimens: {}
+  genera: {}
+  type: {}
+  physic: {}
+  specif: {}
+  subjec: {}
+  city: {}
+  county: {}
+  state: {}
+  countr: {}
+  geogra: {}
+  geonam: {}
+  langua: {}
+  par: {}
+  contra: {}
+  contac: {}
+  rightc: {}
+  rights: {}
+  rightd: {}
+  public: {}
+  identi: {}
+  resour: umn251088
+  audio: {}
+  audioa: {}
+  video: {}
+  projec: {}
+  fiscal: {}
+  publis: University of Minnesota
+  date: 7/19/2013 15:13
+  format: image/jp2
+  digspe: image/tiff
+  digspa: '29523140'
+  digspb: '24'
+  digspc: '300'
+  digspd: none
+  digspf: '2757'
+  digspg: '3566'
+  digsph: i2s CopiBook
+  digspi: Adobe Photoshop CS
+  digspj: Windows XP
+  digspk: 459dbf59db4d88bd15010b464815d48d
+  transc: |-
+    n
+    WKBkWKKKSkWBMIIIIIIIMKtlMltkVt^^WK
+    4sfi.
+    12
+    HEATWOLE'S DAIRY PAPER
+    HOG CHOLERA AT HANLEY FALLS
+    Hundreds of Hogs Have Already Been
+    Taken  by This  Disease.
+    Cholera is killing off the hogs in
+    the vicinity of Hanley Falls, the losses in each instance ranging all the
+    way from twenty to seventy. It is
+    said that the disease has been prevalent in that vicinity for the past two
+    months and that its spread has been
+    caused in part, no doubt, by negligence.
+    The State veterinarian was called to
+    investigate the matter, says the Hendricks Pioneer of last week.
+    . In regard to hog cholera and swine
+    plague the revised laws of 1905 provide as follows:
+    Sec. 5011. Diseased animals—disposal of carcasses, etc.—Every person
+    owning or having in charge any domestic animal that has died or been
+    killed on account of disease shall immediately bury the carcass thereof at
+    least four feet deep in the ground or
+    cause same to be consumed by fire.
+    No person shall sell, offer to sell, or
+    give away such carcass when the animal died or was killed on account of
+    disease nor convey the same upon any
+    public road or upon any land not his
+    own. Nor shall any person negligently or willfully permit diseased animals owned or controlled by him to
+    e-icape his control or to run at large.
+    Every violation of any provision of
+    this section shall be a misdemeanor.
+    Sec. 2165. Offences and penalties—
+    Every person violating any provision
+    of this chapter, or any rule or regulation made hereunder by the State
+    board or any local board of health, or
+    any order made by either under the
+    authority of this chapter, shall be
+    guilty of a misdemeanor, the minimum punishment whereof shall be a
+    fine of twenty-five dollars, or imprisonment thirty days.
+    Hog cholera and swine plague resemble each other, and as both are
+    equally contagious, the same measures
+    must be used in prevention and control. When several hogs die within a
+    short time, it may be safely assumed
+    that the cause is due to either hog
+    cholera or swine plague, or both diseases at the same time and the following instructions should be closely followed:
+    Report the matter at once to the
+    health board of your township.
+    Bury or burn at once all hogs which
+    have died   of  any  disease.
+    Confine the hogs to enclosures remote from the public highway.
+    Disinfect hog pens and enclosures
+    by sprinkling with the following solution; carbolic acid, crude 1 lb. to
+    five gallons water, or air slacked lime
+    instead may be used daily.
+    Hogs should be kept in dry pens.
+    Dogs must, be tied up as they carry
+    the disease.
+    Cedar Swamp Poultry Farm
+    F. J. DAMANN, Proprietor
+    Forty Varieties
+    of standard bred Geese,
+    Ducks, Turkeys, Chickens, Pea Fowls, Guineas,
+    and Rat Dogs.
+    New Catalog
+    shows cuts of my stock
+    taken from life, just as it
+    appears in my yards.
+    The largest poultry ranch in the Northwest.    Stock at very low prices.    Write
+    F. J. DAMANN,
+    Farmington,    -    Minnesota
+    Wagons or hog racks used to remove
+    dead hogs must not be taken on a
+    neighbor's farm.
+    Only the one whose duty it is to feed
+    the animals should be allowed near
+    the pen, this attendant to keep away
+    from neighbor's hogs.
+    As preventive measures when the
+    disease exists in the neighborhood
+    the following precautions should be
+    observed:
+    Do not visit your neighbor's hog
+    pens or enclosures, nor allow any unauthorized person to go into your
+    own hog pens or enclosures.
+    Keep  your  dog tied up.
+    Do not allow your hogs to run
+    about, keep them in small dry pens or
+    enclosures.
+    Give the hogs a small quantity of
+    carbolic acid in feed or water, 3 to
+    15 drops, according to age. This will
+    keep the feeding troughs disinfected
+    and will have a tendency to check the
+    development of the germs.
+    In buying and selling hogs for
+    breeding purposes they should be
+    crated and expressed, as the law explicitly states that no hog may be taken from a stockyard except for immediate slaughter.
+    Breeding hogs shipped in from another point should be kept apart for
+    at least two weeks before being placed
+    with other animals of its own kind.
+    If an outbreak of the disease has
+    been experienced, no fresh hogs may
+    be permitted to be brought into the
+    infected premises until six months
+    after the last hog has died or recovered.
+    Do not think that your hogs are immune from either of these diseases,
+    and every effort should be made to
+    follow out the abovo instructions, ae
+    they are for your benefit.
+    Intelligent prevention is much more
+    satisfactory than treatment.
+    Some winter   is    always    sent   to
+    those who have a great work to do.
+  transl: {}
+  fullrs: Volume13/umn251088.tif
+  find: 571.jp2
+  dmaccess: {}
+  dmimage: {}
+  dmcreated: '2014-02-13'
+  dmmodified: '2014-02-13'
+  dmoclcno: {}
+  dmrecord: '799'
+  restrictionCode: '1'
+  cdmfilesize: '1069601'
+  cdmfilesizeformatted: 1.02 MB
+  cdmprintpdf: '0'
+  cdmhasocr: '1'
+  cdmisnewspaper: '0'
+  page: []
+  id: nfh/799
+- pagetitle: Page 13
+  pagefile: 572.jp2
+  pageptr: '800'
+  title: Page 13
+  photog: {}
+  contri: {}
+  descri: {}
+  dat: {}
+  publia: {}
+  dimens: {}
+  genera: {}
+  type: {}
+  physic: {}
+  specif: {}
+  subjec: {}
+  city: {}
+  county: {}
+  state: {}
+  countr: {}
+  geogra: {}
+  geonam: {}
+  langua: {}
+  par: {}
+  contra: {}
+  contac: {}
+  rightc: {}
+  rights: {}
+  rightd: {}
+  public: {}
+  identi: {}
+  resour: umn251089
+  audio: {}
+  audioa: {}
+  video: {}
+  projec: {}
+  fiscal: {}
+  publis: University of Minnesota
+  date: 7/19/2013 15:13
+  format: image/jp2
+  digspe: image/tiff
+  digspa: '28051162'
+  digspb: '24'
+  digspc: '300'
+  digspd: none
+  digspf: '2629'
+  digspg: '3553'
+  digsph: i2s CopiBook
+  digspi: Adobe Photoshop CS
+  digspj: Windows XP
+  digspk: 55dbb053fee447a7bb65286d01ec6a65
+  transc: |-
+    HEATWOLE'S DAIRY PAPER
+    13
+    GOODHUE FARMERS CLUB.
+    Bigger   Production   and    Increase   in
+    Number of Farms.
+    There are certain things especially
+    to be desired and sought for in connection with agriculture, says the
+    Press committee oi the Goodhue
+    Farmers club in the Kenyon Leader.
+    First—That the number of farmers
+    should be increased. Almost ail other
+    workers are jealous of competition
+    and of being crowded in their work
+    and of having the supply of labor
+    greater than the demand, thus reducing wages. But there is no such feeling among the farmers. The life of
+    the world depends upon their labor,
+    and it is hardly possible to raise
+    more crops than the world can consume. Minnesota is pre-eminently an
+    agricultural State, and her farmers are
+    numbered by the tens of thousands.
+    But there is room for more. The newcomer will be welcomed. He can not
+    possibly harm the farmers nor reduce
+    the price of their farm products, because a hungry world is waiting for
+    all that we can produce.
+    Second—But even more important
+    than the increase in the number of
+    farmers by immigration into the State,
+    either from other States or foreign
+    countries, is the selection of farming
+    as their occupation by the families,
+    the sons and daughters of the farmers—in other words, loyalty of the
+    country people to country life.
+    It is a very important problem how
+    to maintain a proper balance between
+    the country and the cities. Many
+    country lads go to the cities and become most important factors in developing the business of the cities.
+    Very few city boys go to the country,
+    and those who do are not generally
+    remarkable for their success in farming. It is almost necessary for the
+    health of the country that there
+    should be a constant infusion of country blood and vigor into city life.
+    But it is not desirable that there
+    should be too much of this. Agriculture is in a large sense the life of our
+    country. It is desirable that a large
+    percentage of country boys should
+    stick to the farm. I am quite sure
+    that those who do will stand a better
+    chance of success and be far more certain of independence and happiness
+    than most of them would if they
+    should try their fortunes in the city.
+    i^M
+    Should Be Remedied.
+    The current issue of Heatwole's
+    Dairy Paper of Northfield contends
+    that the State Fair association is giving undue attention and showing partiality to the beef producing interests,
+    while the great dairy interests of the
+    State suffer accordingly. It is held
+    that as Minnesota is more interested
+    in the raising of dairy cattle, dairy
+    stockmen  ought  to  at least have  a
+    (VESTER
+    A Good
+    ryInvestment
+    IT will put you in the modern way of With an I. H. C. Cream Harvester on
+    dairying.    That   will  mean   many your place you will haul pure cream to
+    advantages   over  what  you   have market instead of whole milk,
+    now. You will feed  your pigs and  calves
+    "It will mean that you can  keep  more fresh, warm, sweet skimmed milk from
+    cows, carry on a biggerbusiness in milk the   separator,   instead of cold,  sour,
+    and cream marketing or butter making, perhaps tainted milk, hauled back from
+    make   a   better annual  profit, and  do the creamery,
+    all with less labor than you require now. You will do your dairy work up quickly
+    You are keeping cows  for  the  profit morning and evening,  instead of pro-
+    there is in them. You want to get the most longing the work for 12 or 24 hours,
+    possibleout of them. The best way todo I.  H.   C.   Cream  Harvesters  possess
+    it is to get an I. H. C. Cream Harvester, every desired requisite.    They are easy
+    The extra profits you will  make  will to clean,   easy  to turn, and skim  to a
+    soon enable you to pay for your machine, trace.
+    After that  these  extra  profits  are  all Two brushes which go with each ma-
+    clear gain, for you will find your I. H. C chine and a pail  of hot water enable
+    Cream Harvester so simple and substan- you to make short work of cleaning,
+    tial that it will last you many years The I.  H    C.   Bluebell  Cream  Har-
+    Among the  advantages  you  will  re- vester has a  gear  drive.    The I. H. C.
+    ceive from an I. H. C. Cream Harvester Dairymaid is chain driven,
+    are these: Each  machine  is  made  in  different
+    You   can   run   your  dairy  with  less sizes and both are so simple that there
+    labor. "is not the least chance of their getting
+    You can  keep  more  cows  with  the out of order,
+    same labor. Call on the local International  agent
+    You   can  make   higher   grade   dairy for all particulars  or  write  the  Home
+    products. Office   for   catalogue   and   lithograph
+    You can greatly increase your profits, hanger.
+    INTERNATIONAL HARVESTER COMPANY OF AMERICA, CHICAGO, ILL,
+    (Incorporated)
+    fair show with beef stockmen at the
+    State fair. The Dairy Paper says premiums aggregating $2,500 were won by
+    a breed of beef cattle while barely a
+    fifth of that amount was extended for
+    the encouragement of a breed of animals in which the people of the State
+    are most vitally interested. For a
+    commonwealth known as the "Bread
+    and Butter State" this showing does
+    surely seem to be contrary to what
+    ought to be naturally expected. Heatwole's Dairy Paper intimates very
+    strongly that the fair association is
+    controlled by wrong interests to give
+    all a fair show. If this be so, steps
+    ought to be taken with no unnecessary
+    delay to remedy the matter, as no
+    suspicion of gratifying the special interests of any class to the detriment
+    or injury of another should be given
+    jrounds for existence.—Houston County Chief.
+    Charity for revenue is a dead loss.
+    Curing Farm Bacon.
+    Take a gallon of pure water, hard
+    or soft, and to every gallon of water
+    needed to cover the meat add 1V4 lbs.
+    salt, % lb. sugar and % oz. saltpeter.
+    Place meat in a barrel and weight
+    down before pouring on the brine,
+    which must be cold, with all of the
+    ingredients well dissolved. After it
+    has been in the brine 2 to 4 weeks lift
+    out and hang in a smokehouse a day
+    or two to dry, before smoking. Clean
+    odorless wood should be used for
+    smoking any meat, and the smoke
+    should be conducted to the smoke
+    room through a channel or flue from a
+    fire built outside and 6 to 8 feet away.
+    Smoke until the outside of pieces are
+    a nice light brown or a good tan color.
+    Bacon so cured, cut thin and fried or
+    broiled until crisp, served with eggs,
+    makes a dish that adds much to life's
+    enjoyment.
+    Faith is foresight .
+  transl: {}
+  fullrs: Volume13/umn251089.tif
+  find: 572.jp2
+  dmaccess: {}
+  dmimage: {}
+  dmcreated: '2014-02-13'
+  dmmodified: '2014-02-13'
+  dmoclcno: {}
+  dmrecord: '800'
+  restrictionCode: '1'
+  cdmfilesize: '1014237'
+  cdmfilesizeformatted: 0.97 MB
+  cdmprintpdf: '0'
+  cdmhasocr: '1'
+  cdmisnewspaper: '0'
+  page: []
+  id: nfh/800
+- pagetitle: Page 14
+  pagefile: 573.jp2
+  pageptr: '801'
+  title: Page 14
+  photog: {}
+  contri: {}
+  descri: {}
+  dat: {}
+  publia: {}
+  dimens: {}
+  genera: {}
+  type: {}
+  physic: {}
+  specif: {}
+  subjec: {}
+  city: {}
+  county: {}
+  state: {}
+  countr: {}
+  geogra: {}
+  geonam: {}
+  langua: {}
+  par: {}
+  contra: {}
+  contac: {}
+  rightc: {}
+  rights: {}
+  rightd: {}
+  public: {}
+  identi: {}
+  resour: umn251090
+  audio: {}
+  audioa: {}
+  video: {}
+  projec: {}
+  fiscal: {}
+  publis: University of Minnesota
+  date: 7/19/2013 15:13
+  format: image/jp2
+  digspe: image/tiff
+  digspa: '29523140'
+  digspb: '24'
+  digspc: '300'
+  digspd: none
+  digspf: '2757'
+  digspg: '3566'
+  digsph: i2s CopiBook
+  digspi: Adobe Photoshop CS
+  digspj: Windows XP
+  digspk: a4af8cb5d97d604f7e648a17ac87dd45
+  transc: "14\nHEATWOLE'S DAIRY PAPER\nHAY OR ENSILAGE.\nA Comparison that Farmers
+    Can Well\nAfford  to  Study.\nCan you find the mora! in the following camparison
+    of figures?\n1 ton of hay equals 400 cubic feet.\n8 tons silage equals 400 cubic
+    feet.\n1 ton hay equals 1,680 pounds dry\nmatter.\n8 tons silage equals 3.360
+    pounds\ndry   matter.\n1 ton hay equals 886 pounds digestible nutrients.\n8 tons
+    silage equals 2,094 pounds\ndigestible nutrients.\nThose who feed stock in any
+    kind of\nthoughtful way are no doubt familiar\nwith the many advantages of silage\nover
+    hay, yet in the above light there\nis a striking comparison in which the\ntwo
+    feeds are measured by three\nstandards. The hay and silage each\nrepresent about
+    the yield of half an\nacre.\nIn the first instance the space\nwhich each feed
+    occupies is compared.\nHay being bulky requires 400 cubic\nfeet for one ton. Eight
+    tons of silage\ncan be stored in the same space. Suppose that in place of building
+    barns\nand hay sheds, silos were substituted.\nThe storage space could be reduced\njust
+    exactly to one-eighth, according\nto the above. Think of the economy\nthereby
+    resulting—less original expense and less incidentals such as annual repair, painting,
+    etc.\nWe have heard it said that silage\nlacked body; that it was washy and\nconsequently
+    contained little nourishment. But note the comparison. One\nton matter as an equal
+    volume of silage. By dry matter is meant the feed\nless the moisture it contains.
+    Hay ordinarily in a state to Keep well, contains about twenty or thirty per cent\nmoisture,
+    while of silage about half\nthe weight is water. This large\namount of water in
+    silage is what\ngives it succulence, which in turn\nmakes for palatability—a feature\nwhich
+    makes silage so valuable when\nonly dry feed is available.\nThe digestible nutriment
+    in any\nfood indicates its real value. Not all\nof the flesh-forming or fat-forming
+    elements found in foods are available or\nin other words digestible. Thus in\nthe
+    above table it will be seen that\nthe per cent of digestible nutriments\nin hay
+    is much lower than in silage.\nThis fact enhances the value of silage still more.
+    By comparison of\nequal volumes of the two feeds, hay\nsupplies less than one-half
+    as much\ndigestible nutrient as silage.\nThe comparison could be carried\nfurther
+    if desired, and figures given to\nshow the superiority of silage, on account of
+    its succulence, over dry feeds.\nIn experiments it has been found\nthat corn in
+    the form of silage made\n$£Q.50   ^iDirec! From Factory^Jilou\nXW^P~^^   ^| jffegi.
+    Backed By S2E.00O Guaranleo.\\ J      g\nFreight\nPrepaid\n30 Days'_\nFree Trial\nWagon-Box\nManure
+    Spreader\t\nOnly Endless Apron Force Feed Spreader Made.\nSaves You 50%\nJUST
+    that.\nIt's been a loner time getting here—but\nI've got it.\nThe Only Endless
+    Apron Force Feed Manure\nSpreader in the World.\nThe Only Wagon-Box Manure Spreader
+    on\nthe market.\nThink of the combination!—Just the two\nthings in a manure spreader
+    the farmer has\nalways wanted.\nThe wise ones said it couldn't be done.\nI've
+    disappointed them.\nFirst—they said a wagon-box\nspreader wouldn't work.—My hundreds
+    of well satisfied customers\nhave already stopped that talk.\nThen—when it came
+    to an endless apron force feed machine—\nthey said, \"impossible\". Did you\nhave
+    free mail delivery, telephone\nor a cream separator ten years ago ?\nNothing is
+    impossible! You will\nsay so when you see how simple\nand how wonderfully effective
+    my\ngreat new improvement is.\nIt is simply turning the spreader\nbusiness right
+    end to and giving the\nfarmer a chance.\nEvery farmer can afford a Galloway Wagon-Box
+    Spreader.\nI want every farmer in the United\nStates to own one.\nThat's why I
+    sell it direct to you, saving you\nevery cent.    (Tell your neighbors.)\nRight
+    at the start I am selling this machine\nfor $59 SO, freight prepaid. At retail
+    it would\ncost you $75.00. I also save you tying up $50.00 to\n$70.00 in a spreader
+    truck useless eleven\nmonths in the year.\nMy guarantee is the broadest possible—I\nback
+    it up to show you that I mean business by\na $25,000 legal bond.\nThen to absolutely
+    convince you I say, \"try\none  of my spreaders for 30 days on my free\nWilliam
+    Galloway,\nBuilder of the Only Endless\nApron Force Feed Manure\nSpreader in the
+    World.\nplan.\" Let me send you one to take out in the\nfield to use, or abuse
+    if you want to, for 30\ndays. If it's not worth more than my price—\ntake it to
+    the depot—ship it back—and I'll return your money.\nWhy not get everything that's
+    coming to you\nout of your land? That manure heap outside\nof your barn will buy
+    my spreader twice over\nfor you.\nEvery farmer has been saying,—\"I   must   [f\nown
+    a spreader.\"\nForty-nine out of fifty say the old\nstyle horse-killing machine
+    is too\nhigh in price.   Isn't that a fact?\nNow, I claim the Galloway is\nright
+    in every particular.\nMade in three sizes—capacity\n50 to 60 bushels. Fits any
+    truck,—\nnarrow or wide tread. Lightest\ndraft and simplest machine made\nand
+    the work it does under all conditions is perfect.\nWhy not let me send you a machine—and
+    letyou be convinced by\nthe machine itself, without Bending\nme a cent? I'll do
+    it today if you\nwill write me.\nI have just this further clincher\nto offer you.
+    For a limited time I\nwill make a proposition to the Hist\nfarmer owning a Galloway
+    Spreader\nin every community whereby lie can\npartly or entirely pay for his machine
+    without\na bit of work done. It'-s a strictly business\nproposition and will positively
+    hold good only\nfor the firstfew farmers buying. Either send\nin your check pinned
+    to this ad, telling me the\nStyle of truck you use, or write me at once,\npostal
+    or letter, so I can send yon by return\nmail my free booklet.   Address me personally\nWILLIAM
+    GALLOWAY, President,\nWILLIAM GALLOWAY COMPANY,\n^9   Jefferson St., Waterloo,
+    Iowa,\nAsk r^       so for my large Farm Implement Catalog.\nTHE ONLY WAN  IS
+    THE GALLOWAY-FROM FACTORY TO FARM.\"     aaammmmatmaaam\na  much  larger yield
+    of milk than in\nthe form of dry fodder.\nAs a source of cheap forage the\ncorn
+    plant is coming to be recognized,\nthough slowly, more and more each\nyear. Some
+    hay is needed, but the\npresent practice of maintaining a\nlarge acreage of meadow
+    on high\npriced land and feeding hay exclusively to all kinds of farm stock is\nan
+    expensive one, indeed. The figures\nat the top are worth studying.—Iowa\nHomestead.\nElsewhere
+    in this number of Heatwole's Dairy Paper will be found an\nadvertisement of the
+    Northfield Manufacturing Company showing the merits of the Boss Litter carrier.
+    This\ncarrier is built upon honor and any\nfarmer buying of this firm will be
+    honestly and fairly treated. This device\nis a great labor saver and farmers\ncan
+    all afford to have them. Write\nfor  descriptive  circulars   and   prices.\nHere
+    is Another Way.\nA farmer says he rid his farm of\nrats in the following manner:
+    \"On\na number of pieces of shingles I put\na half teaspoon of molasses, on that\nI
+    put a small quantity of concentrated\nlye, then put the old shingles under\nthe
+    cribs. The next morning I found\nabout forty dead rats and the rest left\nfor
+    parts unknown. I have cleared\nseveral farms in the same way. In\nfact I never
+    knew it to fail.-—Exchange.\nA. T. Budlong, of Glenville. Minn.,\ncalled at the
+    office of Heatwole's Dairy Paper last week. Mr. Budlong is\none of the best dairy
+    farmers in Freeborn county and conducts his breeding\nand methods of handling
+    dairy cows\nin a scientific manner. He has one\nof the best herds of high grade
+    Holstein cattle in the State. He has been\nweighing and testing milk from his\nherd
+    for years and does not keep any\nboarders in the barn."
+  transl: {}
+  fullrs: Volume13/umn251090.tif
+  find: 573.jp2
+  dmaccess: {}
+  dmimage: {}
+  dmcreated: '2014-02-13'
+  dmmodified: '2014-02-13'
+  dmoclcno: {}
+  dmrecord: '801'
+  restrictionCode: '1'
+  cdmfilesize: '1384982'
+  cdmfilesizeformatted: 1.32 MB
+  cdmprintpdf: '0'
+  cdmhasocr: '1'
+  cdmisnewspaper: '0'
+  page: []
+  id: nfh/801
+- pagetitle: Page 15
+  pagefile: 574.jp2
+  pageptr: '802'
+  title: Page 15
+  photog: {}
+  contri: {}
+  descri: {}
+  dat: {}
+  publia: {}
+  dimens: {}
+  genera: {}
+  type: {}
+  physic: {}
+  specif: {}
+  subjec: {}
+  city: {}
+  county: {}
+  state: {}
+  countr: {}
+  geogra: {}
+  geonam: {}
+  langua: {}
+  par: {}
+  contra: {}
+  contac: {}
+  rightc: {}
+  rights: {}
+  rightd: {}
+  public: {}
+  identi: {}
+  resour: umn251091
+  audio: {}
+  audioa: {}
+  video: {}
+  projec: {}
+  fiscal: {}
+  publis: University of Minnesota
+  date: 7/19/2013 15:13
+  format: image/jp2
+  digspe: image/tiff
+  digspa: '28051162'
+  digspb: '24'
+  digspc: '300'
+  digspd: none
+  digspf: '2629'
+  digspg: '3553'
+  digsph: i2s CopiBook
+  digspi: Adobe Photoshop CS
+  digspj: Windows XP
+  digspk: f831b3dd68094befc3e0926832636018
+  transc: |-
+    HEATWOLE'S DAIRY PAPER
+    15
+    EDITORIAL  NOTES.
+    There is now and probably will be
+    for some years to come a shortage in
+    the crop of lambs and the price of
+    mutton will be on the increase The
+    cutting up of the ranges will drive
+    the sheep industry into the farmers'
+    hands and the sooner this is done the
+    sooner the noxious weed problem will
+    be solved. Every farmer should keep
+    a few sheep.
+    * *     *
+    It is now high time to be thinking
+    about breeding the cows so that they
+    will be good milkers next rail and
+    winter. Are you going to keep in
+    the line of scrubs and use a scrub
+    sire or are you going to get out of
+    the rut? Read the advertisements of
+    the reliable breeders in Heatwole's
+    Dairy Paper and wrile them if you
+    want to improve yom stocit.
+    * *     •
+    TJ. L. Lashbrock sold a pure bred
+    Holstein-Friesian sire to J. F. De-
+    Wolfe at Barron, Wis., recently.
+    There are not over thirty pure bred
+    sires of this breed within Barron
+    county and the farmers are g.«ing to
+    show the northwest a trick in dairying in a few years that will startle
+    the older dairy sections. They already have the banner creamery in
+    the northwest and last year made
+    more butter than any other creamery
+    in the three States adjoining.
+    * •     •
+    There is  a possibility of the  next
+    National Dairy Show being held in
+    Madison Square Garden, New York
+    city. Milwaukee is also after the
+    great show. There are a few millionaire farmers that want New York,
+    but the rank and file of dairymen
+    would   prefer    some    more    central
+    point.
+    * *     •
+    Remember the annual dairy convention of the Minnesota State Dairymen's Association is to be held at
+    Northfield, January 21st to 23rd. Plan
+    to attend as there will be a good program.
+    * • •
+    Farmers attending the dairy convention in Northfield next month are
+    invited to inspect the stock and dairy
+    buildings at Spring Brook farm only
+    one mile distant from town.
+    * •     *
+    Do not feed the cow simply to see
+    how much milk you can get out of
+    her, but feed her with good farm
+    grown grains and see that she keeps
+    healthy and strong and produces a
+    good calf each year. Ground oats
+    cannot be excelled as a food for cows.
+    * *     *
+    When a man tells you that he has
+    a cow testing five or six per cent in
+    butter fat you do not know any more
+    about the cow than you did before
+    he made the remark. Ask him how
+    many pounds of this kind of milk he
+    gets from her daily and you will soon
+    be able to figure out her value in the
+    dairy. May be a three per cent or
+    a three-two cow would beat her.
+    * * •
+    The packers have been manipulating the pork market during the past
+    few weeks to their own advantage.
+    This up-today and way-down-tomorrow scheme will soon get the farmers
+    to thinking and it will not be many
+    years before there will be co-operative
+    packing plants in the northwest and
+    all will welcome the day when these
+    arrive. Denmark was driven to this
+    many years ago to protect her agricultural interests and America will have
+    to get in line as it did with the successful  co-operative creamery.
+    * *     •
+    W. B. Barney, the popular • breeder
+    of Holstein-Friesian cattle at Hamp-
+    ton, Iowa, has just been re-elected
+    president of the Iowa Dairymen's Association. Mr. Barney is a very capable and efficient officer and has the
+    dairy interests of his State always at
+    heart. The association is to be congratulated upon its selection.
+    * * *
+    Neighborhood or community breeding of one kind of stock is gaining
+    ground every day. It tends to bring
+    neighbors closer together and they
+    spend more time with their stock and
+    find a greater interest in their work.
+    Get this work to going in your neighborhood and see how it will interest
+    the boys.
+    «     *     *
+    The dairy farmer has always got
+    something to do in the winter. If
+    you see a farmer hanging around town
+    all afternoon and at milking time you
+    can safely bet that he is a poor dairyman.
+    * • •
+    Fred Cramer, of Mapleton, Minn., recently purchased a choice young sire
+    and four heifers at Spring Brook farm.
+    The young sire was from a twenty
+    pound dam and is not only a well
+    bred youngster, but a splendid individual as well. At the Holstein show
+    in a class of eleven bulls this fall he
+    was given the championship. Mr. Cramer has the foundation for a very good
+    herd.
+    ■     •     •
+    TJ. L. Lashbrook sold a fine heifer
+    calf to Fayette Lee, of Cokato, Minn.,
+    last week. Mr. Lee contemplates
+    founding a Holstein herd.
+    * •     •
+    A pretty good example of how some
+    folks get mixed on dairy type was exhibited at a recent public sale where
+    a number of almost pure bred Shorthorn cows offered and a beginner
+    in the dairy business purchased three
+    of these aniamls to use in a dairy
+    where a large persistent flow of milk
+    was wanted. He got his eyes opened
+    shortly after getting them home, but
+    that was too late—his cash was spent.
+    Oldest Dairy School.
+    In a historical work on the province
+    of Barndenberg, Germany, there is a
+    description of the draining of a certain swamp district and the establishing by King Fredeick Wilhelm I of
+    a large dairy farm run on the Dutch
+    system with Freisian cows imported
+    in 1719 and 1721. This was made virtually a dairy school for butter and
+    cheesemakers to which the farmers'
+    daughters were sent to perfect themselves in the management of a dairy
+    farm. The term was two years of service after which they had to make butter without help. This was often
+    judged by his majesty and if found
+    good the maids received a dowery of
+    100 thaler ($240).
+    King Frederick II kept it up for a
+    time but, after a while, he turned over
+    most of the land as pasture for fattening imported cattle and added a stable
+    of fine horses. Finally he returned to
+    his father's old plan and re-established
+    the "academy for dairy maids" in 1780
+    with a Hollander, Thomas Harms, as
+    manager, and his three daughters as
+    teachers. After the death of Harms
+    his daughters continued the "school"
+    into the next century but it was less
+    and less patronized.
+    With all its fine name of "academy"
+    I suspect the teachings were pretty
+    slim and that the old king simply used
+    it as a trap to secure the free service
+    of the robust farmers daughters for
+    two years. No wonder he could afford
+    to give "dowries" as premiums.
+    Hard on  Creameries.
+    The newspapers throughout the
+    State are pleading long and earnestly
+    with the farmers to stand by the horns
+    creameries. They are presenting arguments based upon facts and figures
+    but in spite of all they can do the
+    creameries are receiving scant patronage. The LeSueur News says anent
+    this subject.
+    "The creamery is going fast. You
+    may talk to the farmers of your vicinity and learn this. You can do 80
+    right here at LeSueur.
+    "The centralization of creameries
+    and the shipping of milk and cream
+    is turning the trick. The farmers who
+    give away to the plan will live to regret it if the same thing is true in
+    this line that it is all through life.
+    We refer to what happens after the
+    competition is wiped out. Stop and
+    think for a moment. All summer
+    when milk and cream was plentiful,
+    your home creamery was able to compete with the city house, was it not?
+    Now when the pastures are turning
+    brown and feed is very high the city
+    house pays up a notch and is patronized. What is the result? The profit,
+    if any of the summer must be thrown
+    away because the patronage will not
+    pay the expense of operation.    Later
+    WBmWmWmWKmmimmmmmm
+  transl: {}
+  fullrs: Volume13/umn251091.tif
+  find: 574.jp2
+  dmaccess: {}
+  dmimage: {}
+  dmcreated: '2014-02-13'
+  dmmodified: '2014-02-13'
+  dmoclcno: {}
+  dmrecord: '802'
+  restrictionCode: '1'
+  cdmfilesize: '1037926'
+  cdmfilesizeformatted: 0.99 MB
+  cdmprintpdf: '0'
+  cdmhasocr: '1'
+  cdmisnewspaper: '0'
+  page: []
+  id: nfh/802
+- pagetitle: Page 16
+  pagefile: 575.jp2
+  pageptr: '803'
+  title: Page 16
+  photog: {}
+  contri: {}
+  descri: {}
+  dat: {}
+  publia: {}
+  dimens: {}
+  genera: {}
+  type: {}
+  physic: {}
+  specif: {}
+  subjec: {}
+  city: {}
+  county: {}
+  state: {}
+  countr: {}
+  geogra: {}
+  geonam: {}
+  langua: {}
+  par: {}
+  contra: {}
+  contac: {}
+  rightc: {}
+  rights: {}
+  rightd: {}
+  public: {}
+  identi: {}
+  resour: umn251092
+  audio: {}
+  audioa: {}
+  video: {}
+  projec: {}
+  fiscal: {}
+  publis: University of Minnesota
+  date: 7/19/2013 15:13
+  format: image/jp2
+  digspe: image/tiff
+  digspa: '29523140'
+  digspb: '24'
+  digspc: '300'
+  digspd: none
+  digspf: '2757'
+  digspg: '3566'
+  digsph: i2s CopiBook
+  digspi: Adobe Photoshop CS
+  digspj: Windows XP
+  digspk: f79344e0d0fc531e62873c8e4f427d18
+  transc: |-
+    16
+    HEATWOLE'S DAIRY PAPER
+    your creamery will shut down for the
+    winter months, as many have, and
+    then learn they cannot secure a competent buttermaker for a short time
+    in the summer. Finally the home
+    creamery quits. Dies for want of
+    patronage.   Then what happens?"
+    A   FOOL   SIENTIST.
+    Reginald Overocker was a trial to
+    his mother. Mrs. Overocker had unbounded respect for wealth and sought
+    to train her son to esteem ail roads to
+    wealth, including marriage. The son
+    cared nothing for wealth and was absorbed in the sciences. Everybody
+    knows that there is nothing cheaper
+    than brains and nothing more profitable than a knack for getting rich. This
+    is the reason that Mrs. Overocker lamented that her son insisted on wasting his time on chemistry, geology,
+    astronomy, biology—indeed, every
+    science ending in y.
+    But when one day the young man
+    told his mother that he was engaged
+    to Lucy Le Roy, who had come of
+    age and into possession of a large estate at the same time, Mrs. Overocker
+    was much molified. She embraced her
+    son half a dozen times and told him
+    he might waste his time with his sciences to his heart's content.
+    There was one difficulty in the way
+    of Miss Le Roy's peaceable possession
+    of the Le Roy estates. Her grandfather had accumulated tnem, and as her
+    lather, Henry Le Roy, had married
+    her mother contrary to the old Le-
+    Roy's wishes, dying he had left all
+    the property to Peter Le Roy, his
+    only other child, Miss Le Roy's uncle.
+    Peter disappointed the old man by
+    leading a wild, roving life and had
+    twenty-five years before been last
+    heard of in South America. From that
+    time he had not troubled her brother
+    or her brother's family, who at the
+    old man's death had entered into
+    peaceable possession of the estate.
+    But, then, supposed-to-be-dead people have an inconvenient way of turning up when least wanted, and the
+    engagement of the young couple had
+    scarcely been announced when notice
+    was served on Miss Le Roy that her
+    uncle Peter had returned and demanded his possessions. The blow was a
+    severe one to Miss Le Roy and Mrs.
+    Overocker. Reginald was engrossed
+    in his scientific studies and experiments and did not seem to have common sense enough to take notice that
+    he, a poor man, had pledged himself
+    to marry a girl who at the end of a
+    lawsuit—if she contested the claim—
+    would likely be as penniless as himself. His want of appreciation of the
+    fact was very annoying to his mother
+    and correspondingly refreshing to his
+    fiancee.
+    He who claimed to be Peter Le Roy
+    had long lived under the name of
+    Frederick Briggs.    He had very little
+    25 Post Cards FREE
+    T WEN TV-FIVE beautiful Post Cards, printed in colors, on excellent stock and illustrated with
+    any breed of fowl desired, will be sent absolutely free if you send only 25 cents for a year's trial
+    subscription to the POULTRY WORLD. Do not delay, send at once. POULTRY WORLD is
+    a guide to successful poultry keeping and will help you make money out of the business. It is
+    printed monthly on tine booK paper, attractive cover, handsome illustrations, special well known
+    writers. Send 25c for a year's trial subscription and get these beautiful cards free. State breed
+    of fowls with which you wish cards illustrated and mention this paper.
+    POULTRY WORLD CO., - HERON LAKE, MINN.
+    resemblance to the boyish pictures of
+    Peter, but this was not surprising, as
+    few people will easily recognize even
+    a friend not seen in a quarter of a
+    century. He secured the services of
+    a lawyer with a talent for making
+    the most of his points of evidence, and
+    many people had no doubt that he
+    was the real Peter. However, Miss
+    Le Roy's counsel advised her to contest his claim on the ground that he
+    was no one else than Frederick
+    Briggs.
+    It was well known that the real Peter Le Roy when a boy of eighteen
+    had been hit in the temple with a
+    baseball and had consequently lost
+    the use of his right eye. Miss Le Roy's
+    counsel relied on this fact to prove
+    Briggs an imposter and ordered the
+    man before an oculist for examination.
+    Whether Briggs and his counsel
+    knew what their opponet intended to
+    gain by the examination and were
+    prepared for their tests or whether the
+    man was really blind in his right
+    eye, the oculist was unable to prove
+    that he could see with it. However,
+    when the case was called and Briggs
+    had brought the strongest possible
+    proof that he was Peter Le Roy, Miss
+    Le Roy's counsel introduced the oculist, who vainly tried by a number of
+    tests to entrap the claimant into reading with his left eye closed. The trial
+    had reached the climax, and Miss Le
+    Roy was so wrought up over the
+    probability of being reduced to poverty that she prevailed upon her studious lover to leave his sciences for
+    one day and go to court with her. He
+    sat in the court room evidently far
+    away with some problem till the ocu
+    list began his efforts to entrap the
+    claimant. After that he was all attention. When the oculist failed Reginald whispered something to Miss Le
+    Roy's counsel, then left the courtroom. In half an hour he returned
+    and was called upon to examine the
+    claimant's eyes. Giving the man a
+    pair of spectacles to put on, Reginald
+    held a black card before his eyes, on
+    which were words written in green
+    letters, and asked him to read them.
+    This the claimant did without anw difficulty. Reginald glanced at Miss Le
+    Roy's counsel, indicating that he was
+    satisfied, and he was called on for
+    the result of his test.
+    "Of  these   glasses,"  he  said,   "the
+    left is red,    the    right is    ordinary
+    transparent glass. The red glass before what he admits is his sound eye
+    combined with green letters produces
+    black. In other words, through this
+    glass he cannot see the letters at all.
+    Consequently he read them with his
+    right eye, which he claims is opaque."
+    The judge looked at the jury, the
+    jury looked at each other, the spectators tittered, the oculist blushed,
+    while Miss Le Roy beamed on her lover. Then the jury without leaving
+    their seats found a verdict for the defendant, and the property remained in
+    the hands of Miss Le Roy.
+    When Reginald Overocker wa»
+    praised for his shrewdness in unmasking the claimant's rascality he was
+    puzzled. He couldn't understand why
+    such a simple matter should inspire
+    judge, jury, attorneys and a room full
+    of spectators with wonder iwd admiration. However, since he was
+    thereafter permitted to pursue his
+    studies without the intereference of
+    mother.
+    Forget   It.
+    If you see a tall fellow ahead of a
+    crowd,
+    A  leader  of  men   marching  fearless
+    and   proud,
+    And you know of a tale whose mere
+    telling aloud
+    Would   cause  his   proud   head  to   in
+    anguish be bowed,
+    It's a pretty good  plan to forget it.
+    If  you   know  of   a  skeleton   hidden
+    away
+    In  a  closet,  and  guarded,  and  kept
+    from the day
+    In   the   dark;    and   whose   showing,
+    whose sudden display
+    Would   cause  grief  and   sorrow   and
+    lifelong dismay,
+    It's  a pretty good  plan to  forget it.
+    If you know of a thing that will darken the joy
+    Of a man or a woman, a girl or a
+    boy,
+    That will wipe out a smile, or the
+    least way annoy
+    A fellow, or cause any gladness to
+    cloy,
+    It's a pretty good plan to forget it.
+    Since illuminated texts have become
+    all the rage wouldn't this be a good
+    one; "No doctor can cure what ails
+    you.    It's your mean disposition."
+  transl: {}
+  fullrs: Volume13/umn251092.tif
+  find: 575.jp2
+  dmaccess: {}
+  dmimage: {}
+  dmcreated: '2014-02-13'
+  dmmodified: '2014-02-13'
+  dmoclcno: {}
+  dmrecord: '803'
+  restrictionCode: '1'
+  cdmfilesize: '1240879'
+  cdmfilesizeformatted: 1.18 MB
+  cdmprintpdf: '0'
+  cdmhasocr: '1'
+  cdmisnewspaper: '0'
+  page: []
+  id: nfh/803
+- pagetitle: Inside back cover
+  pagefile: 576.jp2
+  pageptr: '804'
+  title: Inside back cover
+  photog: {}
+  contri: {}
+  descri: {}
+  dat: {}
+  publia: {}
+  dimens: {}
+  genera: {}
+  type: {}
+  physic: {}
+  specif: {}
+  subjec: {}
+  city: {}
+  county: {}
+  state: {}
+  countr: {}
+  geogra: {}
+  geonam: {}
+  langua: {}
+  par: {}
+  contra: {}
+  contac: {}
+  rightc: {}
+  rights: {}
+  rightd: {}
+  public: {}
+  identi: {}
+  resour: umn251093
+  audio: {}
+  audioa: {}
+  video: {}
+  projec: {}
+  fiscal: {}
+  publis: University of Minnesota
+  date: 7/19/2013 15:13
+  format: image/jp2
+  digspe: image/tiff
+  digspa: '28051162'
+  digspb: '24'
+  digspc: '300'
+  digspd: none
+  digspf: '2629'
+  digspg: '3553'
+  digsph: i2s CopiBook
+  digspi: Adobe Photoshop CS
+  digspj: Windows XP
+  digspk: 545049d4d2a4be993e2b18f6a8532a3d
+  transc: |-
+    HEATWOLE'S DAIRY PAPER
+    Get the Dairy Habit
+    SEND FOR
+    eattoole's Batrp
+    $aper
+    50 cents for
+    tfjtee pears
+    Subscriptions stopped when time expires
+    The Editor is a plain everyday Farmer and Dairyman
+    =not a Theorist, Politician
+    or Grank. A Dairy Farm
+    of three hundred acres and
+    over, stocked with Pure
+    Bred Dairy Gattle fiu>
+    nishes results.   ::   ::   ::   ::
+    Write today
+    Heatwole's Dairy Paper
+    Northfield, Minnesota
+  transl: {}
+  fullrs: Volume13/umn251093.tif
+  find: 576.jp2
+  dmaccess: {}
+  dmimage: {}
+  dmcreated: '2014-02-13'
+  dmmodified: '2014-02-13'
+  dmoclcno: {}
+  dmrecord: '804'
+  restrictionCode: '1'
+  cdmfilesize: '970276'
+  cdmfilesizeformatted: 0.93 MB
+  cdmprintpdf: '0'
+  cdmhasocr: '1'
+  cdmisnewspaper: '0'
+  page: []
+  id: nfh/804
+- pagetitle: Back cover
+  pagefile: 577.jp2
+  pageptr: '805'
+  title: Back cover
+  photog: {}
+  contri: {}
+  descri: {}
+  dat: {}
+  publia: {}
+  dimens: {}
+  genera: {}
+  type: {}
+  physic: {}
+  specif: {}
+  subjec: {}
+  city: {}
+  county: {}
+  state: {}
+  countr: {}
+  geogra: {}
+  geonam: {}
+  langua: {}
+  par: {}
+  contra: {}
+  contac: {}
+  rightc: {}
+  rights: {}
+  rightd: {}
+  public: {}
+  identi: {}
+  resour: umn251094
+  audio: {}
+  audioa: {}
+  video: {}
+  projec: {}
+  fiscal: {}
+  publis: University of Minnesota
+  date: 7/19/2013 15:14
+  format: image/jp2
+  digspe: image/tiff
+  digspa: '29523140'
+  digspb: '24'
+  digspc: '300'
+  digspd: none
+  digspf: '2757'
+  digspg: '3566'
+  digsph: i2s CopiBook
+  digspi: Adobe Photoshop CS
+  digspj: Windows XP
+  digspk: cd5ed0307a75722ad9f86783a0f8e63d
+  transc: |-
+    sssslWsalsssss^saastslpslslBssssssslsslllss^ia^sssassaaaasa^^BWIIisMsaWMs^^
+    Nothing Succeeds Like Success
+    THE SUCCESS MANURE SPREADER
+    Manure is a valuable asset to the farmer. It is just as important to save and use it as grain.
+    The oldest, most simple and durable manure spreader on  the market.   Send for catalogue.
+    DEERE & WEBBER CO.
+    General Northwestern Agents
+    MINNEAPOLIS
+    The BOSS FEED £
+    LITTER CARRIER
+    THIS is surely an age of invention and
+    that there is no end of the different
+    devices suggested £or the assistance
+    of the farmer in doing his daily work goes
+    without saying. The farm is the place
+    where there is more labor than any other
+    occupation and to arrange to do this labor
+    at the least possible cost is the constant
+    aim. The heaviest work on the farm in
+    the winter months is that of cleaning out
+    the cow stables and the farmer who keeps
+    a good herd of cattle cannot afford to be
+    without a feed and litter carrier. And
+    when getting one he should make it a point
+    to get the very best on the market and this
+    means to get a Boss Carrier. And why?
+    Because it is invented and patented by a
+    farmer who had used others and has made
+    all the improvements possible on such a
+    device.
+    Tho Rncc Purrioi* is the very best automatic car-
+    I IIC DUSS Udl I IBI rieronthemarket.lt is strong
+    and durable and requires absolutely no repairs. It is
+    self-dumping and returns to the barn when unloaded.
+    It is so cheap that it will pay for itself in a very short
+    time and its use will keep the surroundings of the barn
+    in much better condition.
+    Send in the dimensions of your barn and ask for prices
+    forlequipping the same with our carrier, i
+    NORTHFIELD MANUFACTURING CO.,
+    Mfrs. of Farm Inplements. NORTHFIELD, MINN.
+  transl: {}
+  fullrs: Volume13/umn251094.tif
+  find: 577.jp2
+  dmaccess: {}
+  dmimage: {}
+  dmcreated: '2014-02-13'
+  dmmodified: '2014-02-13'
+  dmoclcno: {}
+  dmrecord: '805'
+  restrictionCode: '1'
+  cdmfilesize: '1237866'
+  cdmfilesizeformatted: 1.18 MB
+  cdmprintpdf: '0'
+  cdmhasocr: '1'
+  cdmisnewspaper: '0'
+  page: []
+  id: nfh/805
+id: nfh/806

--- a/spec/fixtures/contentdm/single_page_text.yml
+++ b/spec/fixtures/contentdm/single_page_text.yml
@@ -1,0 +1,75 @@
+---
+title: Bulletin IV, Librarian's Duties, Winona Free Public Library, Winona, Minnesota
+photog: 'Executive Committee, Winona Free Public Library, Winona, Minnesota; Bell,
+  Frederick Somers, 1859-1938; Lees, Edward '
+contri: {}
+descri: The fourth bulletin from the Winona Free Public Library's by-laws, chapter
+  2, article 3, and chapter 1, article 3. The bulletin details the librarian's duties,
+  as well as the assistant librarian, Miss Black, and the first attendant, Miss Von
+  Rohr. It is signed by the library's Executive Committee, Fred S. Bell, Edward Lees,
+  and Mrs. S. W. Morgan.
+dat: 1899 - 1905
+publia: {}
+dimens: 28 x 22
+genera: Politics and Government
+type: Text
+physic: Bulletins
+specif: Libraries; Libraries -- Minnesota; Library administration; Library buildings;
+subjec: Winona Free Public Library; Winona Minnesota
+city: Winona
+county: Winona
+state: Minnesota
+countr: United States
+geogra: {}
+geonam: http://sws.geonames.org/5053180/
+langua: English
+par: {}
+contra: Winona Public Library
+contac: Winona Public Library, 151 West Fifth Street, Winona, MN 55987 http://www.cityofwinona.com/library
+righta: {}
+rightc: No Copyright - United States
+rights: http://rightsstatements.org/vocab/NoC-US/1.0/
+rightd: The organization that has made the Item available believes that the Item is
+  in the Public Domain under the laws of the United States, but a determination was
+  not made as to its copyright status under the copyright laws of other countries.
+  The Item may not be in the Public Domain under the laws of other countries. Please
+  refer to the organization that has made the Item available for more information.
+public: {}
+identi: wpl00053
+resour: umn371579
+projec: Minnesota Reflections 2015-16;
+fiscal: Funding provided to the Minnesota Digital Library through the Minnesota Arts
+  and Cultural Heritage Fund, a component of the Minnesota Clean Water, Land and Legacy
+  constitutional amendment, ratified by Minnesota voters in 2008.
+publis: University of Minnesota
+date: 10/7/2016 15:17
+format: image/jp2
+digspe: image/tiff
+digspa: '28742414'
+digspb: '24'
+digspc: '300'
+digspd: none
+digspf: '2730'
+digspg: '3506'
+digsph: i2s CopiBook
+digspi: Adobe Photoshop CS
+digspj: Windows XP
+digspk: 2cdf3ed96dfa892c27d8715960248a41
+transc: {}
+transl: {}
+fullrs: {}
+find: 31.jp2
+dmaccess: {}
+dmimage: {}
+dmcreated: '2017-01-24'
+dmmodified: '2021-04-26'
+dmoclcno: {}
+dmrecord: '30'
+restrictionCode: '1'
+cdmfilesize: '1037173'
+cdmfilesizeformatted: 0.99 MB
+cdmprintpdf: '0'
+cdmhasocr: '0'
+cdmisnewspaper: '0'
+page: []
+id: p16022coll73/30

--- a/spec/fixtures/contentdm/video.yml
+++ b/spec/fixtures/contentdm/video.yml
@@ -1,0 +1,90 @@
+---
+title: 'Promotional video for Prospective Students 2000, St. Cloud State University,
+  St. Cloud, Minnesota '
+photog: St. Cloud State University
+contri: {}
+descri: Promotional video created to give prospective students and often their parents
+  a view regarding St. Cloud State's academic programs, student activities, faculty,
+  and facilities.
+dat: '2000'
+publia: {}
+dimens: '00:11:18'
+genera: Education
+type: Moving Image
+physic: Home Movies
+specif: College facilities; College publications; College student orientation
+subjec: St. Cloud State University
+city: St. Cloud
+county: Stearns
+state: Minnesota
+countr: United States
+geogra: {}
+geonam: https://sws.geonames.org/5044432/
+langua: English
+par: St. Cloud State Video Collection
+contra: St. Cloud State University
+contac: St. Cloud State University Archives, Miller Center, 720 Fourth Avenue South,
+  St. Cloud, MN 56301-4498 http://www.stcloudstate.edu/library/archives
+righta: {}
+rightc: In Copyright
+rights: http://rightsstatements.org/vocab/InC/1.0/
+rightd: This Item is protected by copyright and/or related rights. You are free to
+  use this Item in any way that is permitted by the copyright and related rights legislation
+  that applies to your use. For other uses you need to obtain permission from the
+  rights-holder(s).
+public: {}
+identi: '14459'
+resour: stc14459
+audio: {}
+audioa: {}
+video: '1_m4ayz74v
+
+  '
+projec: Minnesota Reflections 2019-2020;
+fiscal: Funding provided to the Minnesota Digital Library through the Minnesota Arts
+  and Cultural Heritage Fund, a component of the Minnesota Clean Water, Land and Legacy
+  constitutional amendment, ratified by Minnesota voters in 2008.
+publis: St. Cloud State University
+date: 11/12/2019
+format: video/mp4
+digspe: video/mp4
+digspa: '368050176'
+digspb: {}
+digspc: {}
+digspd: {}
+digspf: {}
+digspg: {}
+digsph: {}
+digspi: Adobe Premiere Pro
+digspj: Windows 10
+digspk: d340724b1144cf42696357c613874786
+transc: "[Music] “I really think SCSU is a perfect-size school.” “Once I walk on this
+  campus, I am very much recognized. I know people; people know me. And once you step
+  on this campus, everyone will know you.” “Any fears that I had totally dissipated
+  within the first couple of days for sure.” [Music] “St. Cloud focuses on hands-on
+  learning and provides many opportunities for students to get involved.” “The professors
+  are very willing to help you at St. Cloud State. They're very concerned about you
+  as an individual.” “There's so much right here in this one campus. They bring it
+  all together for you.” [Music] “I think that one of the most important things to
+  think about when choosing a college is the major program that you're studying, and
+  that's really one of the principal reasons that I chose St. Cloud State, was because
+  I knew that with over 125 programs of minors and majors I could choose from, I’d
+  be able to find something that interested me or met my needs, or that I would want
+  to do for t"
+transl: {}
+fullrs: {}
+find: 9976.mp4
+dmaccess: {}
+dmimage: {}
+dmcreated: '2021-02-10'
+dmmodified: '2022-03-25'
+dmoclcno: {}
+dmrecord: '10069'
+restrictionCode: '1'
+cdmfilesize: '145038'
+cdmfilesizeformatted: 0.14 MB
+cdmprintpdf: '0'
+cdmhasocr: '0'
+cdmisnewspaper: '0'
+page: []
+id: stc/10069

--- a/spec/fixtures/contentdm/video_playlist.yml
+++ b/spec/fixtures/contentdm/video_playlist.yml
@@ -1,0 +1,969 @@
+---
+title: Interview with Chamreun Tan
+photog: Tan, Chamreun
+contri: Frey, Mark
+descri: Chamreun Tan primarily grew up in Battambang City in Cambodia. He was working
+  as a police officer in Phnom Penh City on April 17, 1975 when the Khmer Rouge came
+  to power. He became separated from his parents and siblings and was sent to the
+  village Phum Chhouk to work for the Khmer Rouge until 1979. He married in 1981.
+  Tan attempted to leave Cambodia more than once and was sent back, eventually living
+  in Thai refugee camps until coming to the United States in 1984. He has held a variety
+  of jobs here and is currently a financial worker for Ramsey County.
+dat: '1992-07-30'
+publia: {}
+dimens: {}
+genera: Immigration and Ethnicity
+type: Moving image
+physic: Oral histories;
+specif: Ethnicity; Oral history;
+subjec: Hispanic Americans -- Minnesota
+city: {}
+county: {}
+state: Minnesota
+countr: United States
+geogra: {}
+geonam: {}
+langua: English
+par: Khmer Oral History Project; OH91
+contra: Minnesota Historical Society
+contac: Minnesota Historical Society, 345 Kellogg Boulevard West, St. Paul, MN 51102-1906
+  http://www.mnhs.org
+righta: http://www.mnhs.org/copyright
+rightc: {}
+rights: {}
+rightd: {}
+public: {}
+identi: AV1993_120_13_M
+resour: {}
+audio: {}
+audioa: 1_4d569qcy
+video: 1_or91f5dp; 1_nfct7x5c; 1_0wmrqvpc; 1_ivkawv6u
+projec: Minnesota Digital Library 2013-2015
+fiscal: Minnesota Immigrants is made possible through the generous funding of the
+  Digital Public Library of America Digital Hubs Pilot, which is supported by the
+  Digital Public Library of America with funding provided by the National Endowment
+  for the Humanities and the John S. and James L. Knight Foundation.
+publis: {}
+date: {}
+format: {}
+digspe: {}
+digspa: {}
+digspb: {}
+digspc: {}
+digspd: {}
+digspf: {}
+digspg: {}
+digsph: {}
+digspi: {}
+digspj: {}
+digspk: {}
+transc: {}
+transl: {}
+fullrs: {}
+find: 1122.cpd
+dmaccess: {}
+dmimage: {}
+dmcreated: '2021-07-01'
+dmmodified: '2021-07-01'
+dmoclcno: {}
+dmrecord: '1121'
+restrictionCode: '1'
+cdmfilesize: '326'
+cdmfilesizeformatted: 0.00 MB
+cdmprintpdf: '0'
+cdmhasocr: '0'
+cdmisnewspaper: '0'
+page:
+- pagetitle: Video
+  pagefile: 1120.mp4
+  pageptr: '1119'
+  title: Video
+  photog: {}
+  contri: {}
+  descri: {}
+  dat: {}
+  publia: {}
+  dimens: {}
+  genera: {}
+  type: {}
+  physic: {}
+  specif: {}
+  subjec: {}
+  city: {}
+  county: {}
+  state: {}
+  countr: {}
+  geogra: {}
+  geonam: {}
+  langua: {}
+  par: {}
+  contra: {}
+  contac: {}
+  righta: {}
+  rightc: {}
+  rights: {}
+  rightd: {}
+  public: {}
+  identi: {}
+  resour: {}
+  audio: {}
+  audioa: {}
+  video: {}
+  projec: {}
+  fiscal: {}
+  publis: {}
+  date: {}
+  format: {}
+  digspe: {}
+  digspa: {}
+  digspb: {}
+  digspc: {}
+  digspd: {}
+  digspf: {}
+  digspg: {}
+  digsph: {}
+  digspi: {}
+  digspj: {}
+  digspk: {}
+  transc: {}
+  transl: {}
+  fullrs: {}
+  find: 1120.mp4
+  dmaccess: {}
+  dmimage: {}
+  dmcreated: '2021-07-01'
+  dmmodified: '2021-07-01'
+  dmoclcno: {}
+  dmrecord: '1119'
+  restrictionCode: '1'
+  cdmfilesize: '145038'
+  cdmfilesizeformatted: 0.14 MB
+  cdmprintpdf: '0'
+  cdmhasocr: '0'
+  cdmisnewspaper: '0'
+  page: []
+  id: p16022coll548/1119
+- pagetitle: Transcript
+  pagefile: 1121.pdf
+  pageptr: '1120'
+  title: Transcript
+  photog: {}
+  contri: {}
+  descri: {}
+  dat: {}
+  publia: {}
+  dimens: {}
+  genera: {}
+  type: {}
+  physic: {}
+  specif: {}
+  subjec: {}
+  city: {}
+  county: {}
+  state: {}
+  countr: {}
+  geogra: {}
+  geonam: {}
+  langua: {}
+  par: {}
+  contra: {}
+  contac: {}
+  righta: {}
+  rightc: {}
+  rights: {}
+  rightd: {}
+  public: {}
+  identi: {}
+  resour: {}
+  audio: {}
+  audioa: {}
+  video: {}
+  projec: {}
+  fiscal: {}
+  publis: {}
+  date: {}
+  format: {}
+  digspe: {}
+  digspa: {}
+  digspb: {}
+  digspc: {}
+  digspd: {}
+  digspf: {}
+  digspg: {}
+  digsph: {}
+  digspi: {}
+  digspj: {}
+  digspk: {}
+  transc: |
+    Several pages of the original transcription of the Testimony of Yoeuth Yan have been
+    corrected. They were corrected on 2/17/02 by Beatriz Menanteau, at the University of
+    Minnesota Law School. The corrected pages are the following: 1; 2; 9; 11; 12; 14; 15; 16;
+    17; 18; 22; 26; 29; 30; 35; 37; 38; 39; 40; 42; 43; 44; 45.
+    TESTIMONY OF YOUTH YAN on August 13, 1992, at the Cable Access Studio, St.
+    Paul, Minnesota. The examination was conducted by Ms. Paula Ritchie.
+    MS. PAULA RICHEY: I am Paula Richey and we are here on Thursday, August 13,
+    1992. I am a lawyer-interviewer volunteer in the Khmer Archives Project. The project is
+    under the organization and auspices of the Minnesota Lawyers International Human
+    Rights Committee. With me today is my good friend Yoeuth Yan, who I will be
+    interviewing. We are in the Cable Access Systems offices in downtown Saint Paul.
+    EXAMINATION
+    PR: Yoeuth, would you state your address, please?
+    YY: My address is 1653 Bush, Saint Paul, Minnesota 55106.
+    PR: Are you married?
+    YY: Yes.
+    PR: What is your wife's name?
+    YY: My wife's name is Leang Meak, and I have two children. Chunee is eleven, Chuna is
+    nine.
+    PR: Okay. Do you have any family still living back in Cambodia?
+    YY: Yes, I have my mom, my two sisters and a brothers still inside Thailand; not in
+    Cambodia, inside Thailand. Now they are in Phanat Camp.
+    PR: That is the name of a camp in Thailand?
+    YY: Yeah, that is the name of the camp. Called holding processing centers.
+    PR: Okay. You are employed here in Saint Paul?
+    YY: Yes, I am employed by Southern Minnesota Regional Legal Services and am a
+    paralegal.
+    PR: A paralegal there?
+    YY: Yeah.
+    Khmer Oral History Project
+    Minnesota Historical Society
+    PR: Do you do anything outside of your job for recreation or for some kind of community
+    work?
+    YY: Yes, I do some activity, like playing volley ball or soccer with the young people in
+    the communities.
+    PR: We are here to find out about the kinds of life experiences you had in the years 1975
+    to 1979, under the Khmer Rouge Regime in Cambodia, so I would like to turn your
+    attention then to Cambodia and ask you first of all where you were living in April of '75?
+    YY: 1975; April, 1975, I was living in Battambang City where I went to school there.
+    PR: What school did you go to?
+    YY: Called Battambang School, high school.
+    PR: High school?
+    YY: Yeah.
+    PR: Was your family there in the same town or were they elsewhere?
+    YY: My family, my mom and my parents and my sibling were not there because by that
+    time we were separated by the war and my parents and my sibling were moving to Posat
+    Province and I was in Battambang Province.
+    PR: Who were your siblings? How many siblings did you have?
+    YY: I have seven siblings, including me. Just sibling -- not seven.
+    PR: How many brothers, how many sisters?
+    YY: Four brothers, five four brothers and two sisters. One of my youngest brothers was
+    starved to death in the Khmer.
+    PR: So are the others living?
+    YY: Yeah, they are living.
+    PR: Your youngest brother was the one who died then?
+    YY: Yeah.
+    PR: Tell me what your ethnic origin is; are you Khmer?
+    YY: Yes, I am Khmer.
+    Khmer Oral History Project
+    Minnesota Historical Society
+    PR: So you were in Battambang city in April of 1975. What happened in April? What
+    was the first experience you had with the Khmer Rouge Regime?
+    YY: I think at the New Years when the Khmer Rouge came to power in 1975, April,
+    1975, it came to a town, and then they used the loudspeaker to announce to everybody in
+    town, they announce that everybody have to come out of town immediately because
+    United States jet going to bombard the town in the next few days. And another
+    announcement was for the student, any student in town have to come to the meeting at
+    the Technological University. And others, military officer have to come to the designated
+    area, if you live in this part of town you have to come to this specific place set for
+    military officers.
+    PR: Were these loudspeakers on vehicles going around the city?
+    YY: Some are on vehicle and some…from the wall…from place to place.
+    PR: Did you go to the student meeting?
+    YY: I went to a student meeting.
+    PR: What did they tell you there?
+    YY: At the student meetings, they told us that while everybody have to move out of town
+    for awhile, perhaps seven day or more than that, depending on the situation, when we
+    clean out of the city, clean all the mess of the city and everything, and there is no more
+    enemy in the city, then we can bring you back to a town and you can continue your
+    education.
+    PR: This was the Khmer Rouge saying that, they wanted you to get out?
+    YY: Yeah.
+    PR: So they could clean the city and then you could come back?
+    YY: Yeah.
+    PR: Did you believe what they told you?
+    YY: Yeah, because I believed that, because we were so happy at that time. The war is
+    over and now we are peace.
+    PR: And so where did you go?
+    YY: After that, then we were packed, we were told to pack all our belonging and then I
+    was awhile to one more areas close to my home town. It's about eighty kilometers from
+    my home town, with my second cousin.
+    Khmer Oral History Project
+    Minnesota Historical Society
+    PR: Did you walk?
+    YY: Yeah, we walked.
+    PR: How long was the journey?
+    YY: I forget. I think about two day and one night. Maybe two day and one night.
+    PR: You were with your second cousin?
+    YY: Yeah, I was with second cousin.
+    PR: Were there many people on the road with you? Were you alone?
+    YY: Yeah, there were many, many people on the road. Because all of the people in town,
+    they said while you live only for a few days or short time so you don't have to bring all
+    your belonging. Just go by yourself and you will come back.
+    PR: How did you know to go to the village that you went to? Who directed you to go
+    there?
+    YY: They say, well, on the loudspeaker, they announced that you can goes to your own
+    native town. When they got to my own native town, said no, you cannot stay here. You
+    cannot live here, you have to go further.
+    PR: What did you see along the road?
+    YY: I saw a lot of dead bodies, dead bodies. And some of them were full of maggots. A
+    lot of maggots and just couldn't believe.
+    PR: How did these people die, could you tell?
+    YY: These people were shot to death. Some shot on the head and some were in the
+    abdomen.
+    PR: Were they mostly men?
+    YY: Mostly man. And the dead bodies swell really big; swelling.
+    PR: On this journey, did you see women and children, as well as men, walking?
+    YY: Yes. Everybody from a baby to the adults. And some people are pregnant and
+    deliver the babies on the road and some have no luck and then pass away.
+    PR: Did you see some babies dead?
+    Khmer Oral History Project
+    Minnesota Historical Society
+    YY: Yeah.
+    PR: When you got to the village, close to your home village and they said, no, you can't
+    stay here, you have to move on, did they tell you specifically where to go?
+    YY: Yeah, they just direct us, they put us -- told us the direction, you have to go to this
+    village. This is designated area for your group. Then we went to call it DocTong Village.
+    That is -
+    PR:- DocTong ?
+    YY: Yeah.
+    PR: When you got there, what happened to you?
+    YY: When we got there, then the Khmer Rouge leader came and said, well, since you
+    don't bring much food along with you, so you can come with us and you can get some
+    rice. And they share the rice with us, just a small amount for -- they said one bowl this
+    big (indicating), for fifteen day. Said, well, you have to manage this bowl of rice for
+    fifteen day.
+    PR: And how did you live? What kind of housing did you live in there?
+    YY: Then we were live on the field, open field. We don't have anything. We were
+    provided by the Khmer Rouge leaders with the ax and the knife. And they said, here is
+    the ax and knife and hoe; you can go to the forest and cut the wood and build your
+    shelter.
+    PR: And what did they put you to work doing?
+    YY: About fifteen day, they said while you were single and you are -- because I was
+    nineteen by that time, I just graduated from high school, they said since you are single
+    and you are the front force you don't have any family to be with, so then we will send you
+    to the front force with the team, youth mobile team.
+    PR: Are you saying front force, f-r-o-n-t, front force?
+    YY: Yeah.
+    PR: With the youth mobile team?
+    YY: Yeah.
+    PR: Okay. How many people were on the team or in the team?
+    YY: In my small village there is about thirty people, thirty youth.
+    Khmer Oral History Project
+    Minnesota Historical Society
+    PR: Were they all males?
+    YY: Male and female.
+    PR: Male and female about that same age?
+    YY: About the same age.
+    PR: Thirty of you on the team. What kind of work was the team doing?
+    YY: Then they sent us to the area which is really far from the village to build a dam, to
+    dig the dam and to build a canal.
+    PR: What kind of terrain were you in, what kind of land was this?
+    YY: This is a mountain land, because we call it Phnom Pet; (Phnom mean mountain).
+    PR: Where was the dam situated, on the mountain or at the bottom or where was it?
+    YY: I think on the foot of the mountain, on the foot of the mountain. And we carry - - we
+    push the wooden carts up the mountain in the morning and when we got to the mountain,
+    we break the stone into pieces, and we put the carts and brought back to the dam and
+    down to the river.
+    PR: So did you make one trip a day up the mountain?
+    YY: Not one trip. We have to make, I think, six trip a day. Three in the morning, three in
+    afternoon.
+    PR: And you were on hilly terrain when you were doing this, up and down?
+    YY: Yeah.
+    PR: Men and women both were doing this work?
+    YY: Yeah.
+    PR: How many hours a day did you work?
+    YY: By the time I got up, I believe five o'clock, because still dark, predawn, but we don't
+    know what time. Predawn. And then until the sun set in evening.
+    PR: And what kind of food did you have? Not kind of food, how much food did you
+    have?
+    Khmer Oral History Project
+    Minnesota Historical Society
+    YY: We were provided about this much of rice, this much, just half can of rice for each
+    day (indicating). So we have to find some other sources for our meal.
+    PR: What were those sources?
+    YY: Well, we have to pick up some leaf of tree and small animal or insects in the forest,
+    because in the mountain, for plenty of insects and small frogs, lizards.
+    PR: So you would go out in the forest after you were through working and hunt these
+    things, find these things to eat?
+    YY: Yeah.
+    PR: How many days a week did you work?
+    YY: We work every day, we work every day.
+    PR: You never had days off?
+    YY: No, we never had any day off.
+    PR: Did the Khmer Rouge ever talk to you about their politics?
+    YY: They talk about the "Anka", the organizers and the parties. They talk about a party
+    every night. After dinner they blew the whistle and then all the team have to come to
+    central center for the meeting.
+    PR: And at the meeting, they?
+    YY: They talk about politic, they talk about how to build a country and now we build - -
+    we come to this far, we can complete this project, and we have to build a country from
+    the empty hands to prosperous countries.
+    PR: How did you receive that message? How did you feel about what they were telling
+    you?
+    YY: I was hopeless and I did not know what to do. I just follow what they asked me to
+    do.
+    PR: Did you believe what they were saying?
+    YY: I was not believing what they told me to do, because I look at the situation that they
+    didn't provide us enough food to eat and how can we survive, how can we rebuild a
+    country.
+    Khmer Oral History Project
+    Minnesota Historical Society
+    PR: How did you survive? Did the hard work and the deprivation of enough food, did it -
+    - what happened to you, to your body because of that?
+    YY: I was become skinny and I had malaria. I had malaria because I was not having a
+    mosquito net and so I had malaria. And then the Khmer Rouge leader send me back to
+    my village for treatment to the hospital in my village, the Khmer Rouge hospital, just like
+    a shack in the village.
+    PR: And did you get medicine there?
+    YY: I got some Khmer Rouge medication. But I don't know what kind of medication. But
+    did not help me at all and I was unconscious when I got back to my village. At one time I
+    work up and I realized and I saw my uncle, my second-uncle stand - - stood by me. And
+    then he said, oh, and then he tickled me and said, oh, you know, and then I can smell
+    something from my mouth. I can smell that was the bad excrement and bits of leaf from
+    tree and perhaps coconut fruit. And I didn't realize the others.
+    PR: Had your uncle put these things in your mouth?
+    YY: I believe he told me he pound into pieces and put into water, so like a liquid, become
+    a liquid.
+    PR: Did he think that would help your malaria? Was that the idea?
+    YY: Yeah, that was his idea.
+    PR: Did it?
+    YY: Yeah, it did. And about a few days later, I become better. And about seven day, I
+    asked the nurse, the Khmer Rouge nurse, to leave the hospital. And I was barely walk by
+    that time because I was very skinny and I used a cane. I was nineteen years old and I have
+    no muscle at all. I used a cane to carry my body to my village.
+    PR: Let me ask you, let me take you back in time for just a second. When you were
+    working in the youth team, the mobile youth team?
+    YY: Yeah.
+    PR: Did you see any of the people who were working on the team die?
+    YY: Yes. My, one of my friend, not just one, I think four or five, six of them were dead
+    of malaria. One of my close friends was, he was high school student. And I think he
+    graduated from high school about the same year that I graduated. And he passed away a
+    few days after me, after I got out of the hospital.
+    Khmer Oral History Project
+    Minnesota Historical Society
+    PR: Now, after you came out of the hospital, you didn't go back to the mobile youth
+    team, correct?
+    YY: No, I did not.
+    PR: Where did you go then?
+    YY: I was at this time, they say since you are so weak, you can stay in the village with
+    the villagers, with the second force, the people who got married. They said that those
+    people are second force, not a strong front force. So I stay with them, I think - - I couldn't
+    tell because I didn't know exact time. Awhile, until one day I recall a lot and then I heard,
+    I knew they want to take me away and kill me.
+    PR: You found out that somebody wanted to take you away and kill you?
+    YY: Yeah.
+    PR: Tell us, who told you that?
+    YY: When I got there, they took my watch away and said, well, now, this is Anka, need
+    the watch. "Anka" need the watch. So would you please give it to "Anka". Then I carry a
+    lot of mathematic book ...
+    PR: You were telling me that somebody came to you and told you that you were going to
+    be killed. Now this was after you had recuperated from malaria, correct?
+    YY: Yeah, that's correct.
+    PR: And who came to you and told you that?
+    YY: The head of the village, the head of the village. A small village that I live with, was
+    assigned by the Khmer Rouge after, the head of the village. And he came to me, said,
+    well, now I learned that your father was taken away by these people and now these
+    people came to us and they asked about you. They said this guy is Mr. Yom's son and
+    then the guy said, why we were so afraid to tell and just tell him the truth, that, yeah, and
+    - -.
+    PR: What did they tell him, that you were your father's son?
+    YY: Yeah.
+    PR: And then what did they tell you about your being killed?
+    YY: They said that, well, you are not safe to stay here, you are no longer safe to stay here
+    because I think in the future theses people are going to come after you.
+    PR: Now, why would they kill you because you were your father's son?
+    Khmer Oral History Project
+    Minnesota Historical Society
+    YY: Because my father is - - was - - a well-known person in the areas.
+    PR: Why was he well-known?
+    YY: Because he was chief militia commander of militia... and he was a merchant, he was
+    a merchant also, because the Khmer Rouge hated that class of people.
+    PR: Both the militia and the merchants?
+    YY: Yeah, because he fought against the Khmer Rouge along with the Lon Nol soldier.
+    PR: Lon Nol?
+    YY: Yeah.
+    PR: And so you were warned. Now the person who warned you was doing a brave thing,
+    wasn't he?
+    YY: Yeah. He warned me. And then later on he said, well, you have to leave and I can
+    write you the fake letters, permission for you to travel, and you can go and find your
+    mom and your sibling.
+    PR: Do you have any idea what year this was that this happened?
+    YY: I think this is in 1986, but I am not sure. I think early 1976.
+    PR: Early '86?
+    YY: I'm sorry, '76.
+    PR: So you got this letter of passage or permission to travel and where did you go?
+    YY: I left the village early in the morning and nobody know that I left the village. I left
+    with the old lady because I, at the time, fortunately for me, there was a lady, old lady,
+    came from a zone four to find her son. And her son was in the team, the same team that I
+    belonged to. And she came to take her son back to "zone four". By that time, the head of
+    village said, well, now is time for you, its time for you, you can go with the lady and you
+    can walk along with her and then when you get to zone four, you can go to your mom, to
+    find your mom, because your mom is in zone four, but just different village.
+    PR: Now, what happened to your father?
+    YY: When I came back and when I met my mom, I think at night, because I came at
+    night, and I, when I came - - when I left the village, on the way to the zone four, when I
+    came across the highway five, there is a Cambodian - - we walk along highway five from
+    Khmer Oral History Project
+    Minnesota Historical Society
+    O'Kreart to Pray Sway, and then I saw the guy rode the bicycle from Prey Sway direction
+    and I look at this guy and say, oh, I know this guy, I know this guy. And I stop this guy.
+    And then I knew him right away and I asked Mr. Wang, Mr. Wang, do you know me?
+    And he said no. And I said, do you know Mr. Yom, and Seun. And he said, oh, yeah.
+    Your mom. Then he surprised and said, are you Yoeuth? And I said yes. And he said
+    your mom live close to me. And I said, can I come with you to my mom, because I was
+    on the way to zone four and I want to find my mom, but I have no idea. He said yes. Then
+    I didn't go along with the old lady and her son anymore, I come with this old man. And
+    then when I got to my mom's village, I think around midnight, and then he knock at my
+    mom's shack and said Seun, Seun, I brought important stuff, thing, for you; good thing
+    for you. Please light your lantern, light your lamp and wake all your children up and
+    prepare the meal also. Then my mom got up and light the lamps and my - - all my
+    siblings woke up and my mom got up and cry, and - - .
+    PR: I bet you were very, very glad to find her?
+    YY: Yeah.
+    PR: Do you want to stop for a minute, Yan?
+    YY: Yeah, that is okay.
+    PR: Do you want to stop for just a minute?
+    YY: Uh-huh.
+    PR: Was it through your mother that you found out what happened to your dad?
+    YY: Yeah. And then my morn woke up and my siblings, my older brother, (Yarn) who is
+    now in Thailand, got up, and my sister now in Thailand, and my two brothers who are
+    now here. And got up, and then my morn just cried, and we all cried in the middle of the
+    night. And she said, well, your dad is gone. Your dad was taken away by the "ankas"
+    fifteen day after we got here.
+    PR: They just came and took him out of the house?
+    YY: Yeah.
+    PR: He wasn't seen again?
+    YY: Yeah. And she said, well, at one point when she got back from the trip, because
+    when my mom and my dad were brought to this village and they allow my father to get
+    out of the village to find some forest to build the shack, my father was not finishing his
+    shack. And he was taken away. And at one point, I can remember right now, he told my
+    mom that would you please take care of children because I know I was not coming back.
+    I know that.
+    Khmer Oral History Project
+    Minnesota Historical Society
+    PR: How long did you get to stay with your family?
+    YY: When I got back to my mom and I stay with my mom, because since that night,
+    very, very heavy raining. Then next morning, I got malaria again. I got fever and chills.
+    Then my mom said, well, I can report to the Khmer Rouge leaders in the village about
+    this because then to get some food, portion of food for you to eat. And next morning my
+    mom report to the leaders, the village leader, the Khmer Rouge leader, and then in the
+    morning, every morning, the Khmer Rouge nurse came by from house to house. Come to
+    visit from house to house, the way that the Khmer Rouge practiced, to make sure that
+    everybody go to work. Anybody sick, they can give you some medication, and to find out
+    if they are really sick or just pretend sick. And when they got to my mom shack, I was in
+    chill. Fever and chill, and they gave me some Khmer Rouge medication. It looked like
+    rabbit excrement. So looked like rabbit excrement. So they gave me that medication and
+    they gave me (Quinide) from China, a pink pill. I took that for seven days. And then I got
+    better and then my older brother was in youth mobile team and said, well, you should go
+    with me. Don't have to wait until the Khmer Rouge told you to do, you can come with me
+    to work. Then I was with my brother for a couple months with his team, because my
+    brother team was assigned to transport the rice from zone seven to zone four by boat
+    because full of water from zone four to zone seven. So I just sat on the boat and my
+    brother and his team rowed the boat because I was real skinny by that time.
+    PR: So how long did you get to stay with the family and work with your brothers?
+    YY: I was with the family, with my mom about fourteen day, I believe.
+    PR: Then what happened to you?
+    YY: And then I was with my brother's team and then later on they said, oh, all the front
+    force have to join with the zone four team, zone four team. Then they - - all the people,
+    all the youth all the youngster who are not married in the village, the whole village
+    gathered together, were gathered together by the Khmer Ronge leaders and then were
+    sent to the zone four. They call it youth mobile team. And I was with that team, I think,
+    until I was sent to concentration camp.
+    PR: Okay. When you were in the zone four youth mobile team, what kind of work were
+    you doing?
+    YY: At first I assigned to do farming work, build dike and canal and plant the rice, pull
+    the seedling rice. And my malaria keep coming back all the time. At one time, I got high
+    fever and chill and I stay home. I asked the Khmer Rouge leader to stay home and ,they
+    said, well, you can stay home. Later on, they say, well, some people who are sick, is not
+    really sick, just pretend to be sick person. Then this people are not useful to "anka"; they
+    said the enemy of the "anka". We should get rid of these people. And one of my group
+    leaders came and told me that, well, you shouldn't stay home anymore when you can go
+    Khmer Oral History Project
+    Minnesota Historical Society
+    to the field, work every day. When you get fever and chill, you can stay - - you can sleep
+    on the dike instead.
+    PR: Sleep on the dike?
+    YY: Yeah, and bring your blanket along. So I bring a blanket along.
+    PR: You were telling us, Yoeuth, about working in the zone four youth mobile team, and
+    you had malaria, and you still went to work?
+    YY: Uh-huh.
+    PR: So that you wouldn't get in trouble with the Khmer Rouge --?
+    YY: Yeah.
+    PR: -- who were running the team?
+    YY: Yeah.
+    PR: Can you tell us about the kind of work you were doing? Farm work, is that correct?
+    YY: Yes.
+    PR: And how were you treated by the Khmer Rouge? Was it different than the kind of
+    treatment you had before in the first front force team? Were the conditions better or
+    worse or the same?
+    YY: The condition was the same. But at this time, I was not breaking the stone or
+    pushing the cart from the rivers to the top of the mountain. And at this time, it's just dig
+    the canal and build the dike. Get up the same time, predawn, four in the morning or five
+    o'clock in the morning, till sunset.
+    PR: Were the food rations about the same?
+    YY: The food ration about the same, about the same.
+    PR: Were the Khmer Rouge -- how did they treat the workers? That is, were they hard on
+    them or did they treat them well?
+    YY: The Khmer Rouge never treat anybody well, except the parties or perhaps the people
+    in the group, the people who joined the team in the revolution. The people they call new
+    people. Those people were treat harshly by the Khmer Rouge. Any place anybody go,
+    because the Khmer Rouge, sometimes the they use the whip, the Khmer Rouge team
+    company, team company leader, carried a whip with them most of the time. If anybody
+    Khmer Oral History Project
+    Minnesota Historical Society
+    did something wrong, not just - - not really big mistake, you know, like you goes to get a
+    shower and you just a little bit late, they would kick you and whip you.
+    PR: Were you ever whipped?
+    YY: Yeah. But I was not whipped at this time, but after, later on.
+    PR: How long did you work in that youth mobile team?
+    YY: I was with the youth mobile team, but first I was assigned to do farming and later on
+    I was assigned the fertilizer team. So I was assigned to fertilizer team, I believe, in 1977.
+    PR: You worked on that team for awhile. You mentioned that you ended up in a
+    concentration camp. How did you end up in a concentration camp?
+    YY: When I was with the fertilizer team, I carries all the excrements of human beings
+    and make fertilizer. Cut the leaf of trees and mix together and all the maggots swimming
+    around. And we have bad smell every day. But you get used to, just do the job. And later
+    on the Khmer leaders said, well, we need a team who really work hard who can help
+    "anka" zone four, and we need strong people who can carry the rice sacks. Then they
+    point out to the people and the team. And say, oh, we need ten people who work really
+    hard who can carry the rice sack, because the rice sack is about eight kilogram for each
+    rice sack. And they look at me and they look at the other people. Because I carry, when I
+    was with to the fertilizer team, I carry the excrement, human excrement, big gasoline can
+    cut into -- split into two -- and I carry that. And very, very heavy. And say, well, this
+    comrade can carry the rice sack because he is really strong. And point, this one. And I
+    was ... and then they sent me to the transportation team in zone four. I was with the
+    transportation team about just a short period of time. Then the northwestern leader was
+    accused the enemy of the central party and they send the southwestern people to take
+    over the whole regions. And then when the northwestern people - - no, southwestern
+    people, they call (Nearaday) came to take over the whole regions, then they say, oh, these
+    people belong to the previous zone leader so we should move these people from this area.
+    Then told you have to get out of this area for awhile until we set the things smooth. We
+    put the thing in smooth transitional way, then we will take you back. But now we have to
+    send you to this area to work for "anka". That is when I end up in concentration camp.
+    PR: So that is where they sent you was to a concentration camp?
+    YY: Yeah.
+    PR: What happened to you there in the concentration camp?
+    YY: When I got to that place, I didn't realize that I was in concentration camp because I
+    thought I was just youth mobile team. And I start realize when they carry weapon. The
+    Khmer leader carried a gun all the time to guard us anyplace we go. And they carry the
+    whip all the time. And when we got there, they told us, now, you are not -- you cannot do
+    Khmer Oral History Project
+    Minnesota Historical Society
+    what you want to do, you are not youth mobile team anymore. Now you are in this camp.
+    You need to be reeducated. This is reeducated camp.
+    PR: What did they do to you?
+    YY: Then they asked, I think four or five thousand, all of us, to dig the dam and build the
+    road, dig the well, plant the rice, build the dike, build a stream, the water stream.
+    PR: So it was sort of more of the same, really?
+    YY: More of the same. But this camp, the soldiers, the Khmer Rouge soldiers guard us
+    all the time. And this really harsh, really harsh treatment from the Khmer Rouge at this
+    time at the concentration camp. In the morning, you have to get up when the Khmer
+    Rouge blew the whistle. You have to get up and then they order you to take a shower at
+    4:00 in the morning. And your body is not really sensitive to the waters because you are
+    very skinny and you hardly walk. Young man like me, when I got up, I have to put my
+    hand on both knee to get up. And we barely walk. This camp, a lot of my friends were
+    killed, a lot…one of my friend was (Phin Ngan), his name was (Phin Me). He was
+    Lieutenant Governor son, Phin Ngan), Battambang Province.
+    YY: And others, two or three was former militia officer, also my friend also; my friend,
+    too. And those were killed, beaten to death on the rice field.
+    PR: Did you see that happen?
+    YY: I did not see what happened, but because, when I was in concentration camp, they
+    separate me from the rest of my team, my former team. The Khmer Rouge came and
+    point to everybody, and then they point at me, do you know how to plow the field? I said
+    yes. And, do you know how to tend the cattle, the ox, the buffalo, water buffalo? I said
+    yes, I can tend the oxen, but I am afraid I am not used to the water buffalo. Then the
+    Khmer Rouge leader says, well, you can do it. So then they picked me out from the team.
+    And then my friend, (Phin Ngan's) son, Lieutenant Governor son, his skin very light, was
+    real light. And he was stayed there, he was not with me. And I was with another team,
+    what they call plowing team. Plowing harrow team.
+    PR: So did you learn about his death from somebody else that was there and saw it?
+    YY: Yes, because in day time we were in the front team, but at night we came to the
+    same shack, we stayed in the same shack at night. So I learned when my friend was taken
+    away one night when I came back from plowing the field. One friend came to me, Mr.
+    (Meng), Comrade (Meng), Khmer Rouge called Comrade (Meng), came to me and said
+    (Phin Me) was taken away today and we don't know where. Since then, we never see
+    him, you know, saw him. And later on Mr. (Doeun), our Comrade (Doeun) was not taken
+    away, he was beaten to death on the rice field with the head of the how.
+    Khmer Oral History Project
+    Minnesota Historical Society
+    PR: Know why?
+    YY: The head of the hoe.
+    PR: Do you know why he was beaten to death?
+    YY: He was carrying seedling rice for another team to plant on the field. And he tripped
+    his leg and fall into the field, the farm field, and fall into the (seedling) the plants, the rice
+    plants, and broke a few rice plant. And the Khmer Rouge say that is the enemy.
+    PR: And they beat him. By doing that, he was an enemy, and beat him for that?
+    YY: Uh-huh.
+    PR: You were in the concentration camp for about a year?
+    YY: Yeah, I think about a year. And when I perform my job, I saw a lot of dead bodies in
+    the farm field. Because run a harrow, my plow and my harrow, I can see the dead bodies
+    and flesh of dead bodies come out from the…
+    PR: The rice field?
+    YY: Yeah, the rice field. And some, I saw red water come out, red water. And then I saw
+    the bone, the bone come out. And then I have to get off from the harrow and pick - - I
+    have to pick up those bone and put on a small hill nearby. And I was with this team when
+    I tended the water buffalo in one the grass land, I saw the (club) of, (club) that the Khmer
+    Rouge soldiers use to beat the people to death. And I saw the leg of people out of the
+    ground, sticking out, and the clothes. And I was so shocked and I think maybe my friend
+    or somebody who was killed here. And the wolf came by and eat all those flesh.
+    PR: The animals?
+    YY: Yeah.
+    PR: Wild animals?
+    YY: Yeah, wild animals.
+    PR: How did you escape from the concentration camp?
+    YY: Until the Khmer Rouge took -- until the Vietnamese took over the whole country.
+    And this concentration camp, I was beaten by Khmer Rouge and here (indicating), my
+    scar on my left eyebrow, is a scar.
+    PR: Why did they beat you?
+    Khmer Oral History Project
+    Minnesota Historical Society
+    YY: One morning, they told me that when the whistle blew I have to get up and run and
+    dress up my clothes and run. I was a little bit late and the Khmer Rouge, when they blew
+    the whistle, one Khmer Rouge blew the whistle and the others carried a whip along and
+    hit. Anybody that didn't have to get up and run. If you don't run, you are going to get
+    whipped.
+    PR: And that is what happened to you?
+    YY: That is what happened to me.
+    PR: Do you have anything else -- do you have any other memories of the concentration
+    camp that stand out in your mind?
+    YY: I have a lot of memories at this concentration camp. I was beaten and I saw the
+    people were killed because a lot of my friends asked me to leave, to escape from this
+    concentration camp. And some of them escaped safely. I met them by the time the
+    Vietnamese took over the whole country. Some of them were not safe. One morning,
+    when we got up and then the Khmer Rouge announced by a loudspeaker, we caught the
+    enemy, we caught one enemy trying to escape from the “anka"~. Would you please
+    gather around in front of young women center, women shack. And then everybody
+    gathered according to the order, and we came and the Khmer Rouge brought this guy, put
+    in front of everybody about three or four thousand people -- and then he chopped this guy
+    with the knife. He opened the abdomen in front of a lot of people, a lot of youngsters.
+    And he pierced his knife into this guys eyes. And this guy scream in pain. And I can see.
+    And he, Khmer Rouge, kick on his head and twist him around.
+    PR: You know, you have described such terrible, horrible things and I can't help wanting
+    to ask you if, after awhile, when things are that bad, do you ever sort of get used to it to
+    the point where it no longer horrifies you? Or did you -- was it always horrible to see
+    these things happen? What I am asking is if you ever sort of got to the place where it was
+    so common to see horrible things that they no longer got to you?
+    YY: Some point, I feel, because I do not put my life in value anymore, I just say to
+    myself, well, I just live from day-to-day. And maybe this day that is him, maybe
+    tomorrow that is me. And I don't care. I am not taking care of my body anymore. I just let
+    it go. If they take me, then that is my life, that is the end of my life.
+    PR: So the feeling was sort of like hopelessness?
+    YY: Hopeless, give up all the hope.
+    PR: Then when the Vietnamese came in in '79, and over-ran Cambodia and defeated the
+    Khmer Rouge, that is when you were liberated, sort of. I don't know if liberated is the
+    right word?
+    YY: Yeah.
+    Khmer Oral History Project
+    Minnesota Historical Society
+    PR: What happened, did everybody take off into the jungle or was it orderly or mad-house?
+    YY: I did not realize that the Vietnamese invade Cambodia. By the time that the
+    Vietnamese came, I was sent to a jungle, to deep jungle. Up north, close to the mountain
+    they call (Pahall), very far away from the first place, the first concentration place. And
+    when we got there, the people around the village, the people around that concentration
+    camp were afraid to talk to us. They never came to us to talk to us at all. Even, I met my
+    second cousin, the one that I escaped from him in 1976 I met him. He came, he walked
+    by, I don't know, accidentally, I saw him. I said to him, (Dorn, Dorn); he didn't even look
+    at me. He just walked by. He passed away, he passed by.
+    PR: Why do you think he did that?
+    YY: I learned that later, when the Khmer Rouge fall apart, when the Vietnamese took
+    over the whole country, he said everybody in surrounding this area, the Khmer Rouge
+    leaders told the people in the surrounding area that you don't have to talk to these people.
+    If you talk to these people, you have a connection with them, then you will be suspicious;
+    you will be spied by the Khmer Rouge.
+    PR: Do you think he knew it was you when you - -
+    YY: Yeah.
+    PR: He did?
+    YY: Later on, I met him, too. And I was so skinny, I was tending the water buffalo and
+    he was casting the net into the stream to catch the fish. And he didn't - - he just glare at
+    his rice pot, and I went there and got the rice. And then I got the rice and I walk away.
+    PR: So you didn't talk because he was afraid of being associated with you?
+    YY: Uh-huh.
+    PR: Right?
+    YY: Yeah.
+    PR: Eventually, did you hook up with your family again?
+    YY: Yes, I went - - I think in April, 1979, and I hook up.
+    PR: Where did you find them or how did you find them?
+    Khmer Oral History Project
+    Minnesota Historical Society
+    YY: When the Vietnamese came, I didn't realize the Vietnamese came, because I saw a
+    lot of Khmer Rouge track. Khmer Rouge vehicle in a long procession. And I realize, of,
+    maybe something wrong with the Khmer Rouge government. And I didn't realize that the
+    Khmer Rouge fall apart. I heard through the Khmer Rouge about fighting Vietnamese
+    and asked all of us to join the military. And said they are known to us, well, if any want
+    to be soldiers, come and join us. We can feed you, we provide plenty of food for you.
+    And at that time, I didn't care. I said, well, I join. I said, you give me food.
+    PR: Did you join?
+    YY: No. Then just -- end of the meeting, we heard the tank, the tank moving, the tank
+    sound shake the ground. The Khmer Rouge vehicle passed just, I think, for about ten
+    minutes and then we heard the tank. Sound of the vehicle I think three day, four nights,
+    something like that, pass. And I realize, oh, this is something wrong. The Khmer Rouge
+    must fall apart. The Khmer Rouge must fall apart. And then the Vietnamese tank came
+    and they shoot at the Khmer Rouge and Khmer Rouge spread into the mountain, close to
+    the mountain at that point, and they ran to the mountain. And then the Vietnamese tank
+    ran up to them and shoot at them. And we got back and all of my teammates, the people
+    who are in my team, got together and I couldn't walk and we raid they call Economic
+    Center, Khmer Rouge Economic Center. That center have plenty of all kind of food: fish,
+    rice, and tire. I think needle and sewing machine, the truck, the cow. All the livestock
+    were raised there. And we all ran into the cage and catch the duck and chicken, and we
+    kill and make food. And we were there, we celebrate. We were there about 7 days, we
+    don't care when the Khmer come back and kill us. We didn't think about that. I did not
+    think about that at all.
+    PR: Had the Khmer Rouge that were running your camp, had they taken off, had they
+    gone?
+    YY: They gone, they run away. When the tank - - the Khmer tank came. And I saw the
+    Khmer Rouge throw away the bicycle and I told my friend, I want to get that bike, I want
+    to get that bike. Maybe I can ride that bike to my village and we can celebrate. We are
+    liberated and we survived again...
+    PR: So you had this great huge party using up the Khmer Rouge storage camp?
+    YY: Uh-huh.
+    PR: Where did you take off for?
+    YY: Then I stayed until I have enough strength, about seven days or more than seven
+    days. I have enough strength, and I am strong right now. Then we move. Then the
+    Vietnamese soldier come back from the top of the mountain with the tank and shoot and
+    said, (dee, dee, dee, dee), and (dee) mean go, go. Then we pack and we move to - - and
+    say you go this way, this way, this way. And the Vietnamese soldiers pick you up if they
+    Khmer Oral History Project
+    Minnesota Historical Society
+    see anybody who really good shape, (Pol Pot, Pol Pot), they say, (Pol Pot) ... and they
+    catch that person if anybody is good shape.
+    PR: Looking good?
+    YY: Yeah.
+    PR: So did you head out for your home village or go off to Thailand?
+    YY: I head out for my home village for the first time. But on the way to my home village,
+    I meet a guy and that guy came and I keep asking them is they know where my family
+    live, my family pass away or were killed. And I asked this guy all along the way because
+    by that time some people who were liberated before us, perhaps late 1978, December,
+    1978, they came to gather all the stock, all the stuff, they used the ox cart to carryall the
+    rice. They took all the rice back to the village. And I keep asking those people who come
+    to collect, to gather all the belongings. And then I met a guy, guy said, well, I know, I
+    know this guy. And I asked him, do you know this guy and then I asked about my father
+    and where my home town is. Oh, I have a friend who used to live in Anokob village. And
+    I said who is he, and he says, Muth. I said, oh, that is my third cousin. Where is he? He
+    says he is up there. He point to me, and come with us to collect all of the rice. I say can I
+    see him? When I walk to him, he didn't know who I was. And then I said, I am Mr. Yan
+    son, and yom and (Seun Yan) son. I am Yoeuth. And said, oh. Then he know. And said, I
+    know, I can take you to your mom, because he didn't call my mom name. He call mom.
+    So I came with him to the village where my mom and my siblings stayed. And we were
+    there in that village for, I think, until late 1979. We head for refugee camp.
+    PR: You all left together?
+    YY: No, no. The first time, reason that I left Cambodia because my older brother, the one
+    inside, in Thailand right now, he was accused of liberation force, liberation network,
+    what you call Khmer freedom, Khmer liberation friend.
+    PR: Uh-huh.
+    YY: And he joined with that network and he was accused by his friend, who worked for
+    Vietnamese authorities, and my brother was arrested. And then this guy send my brother
+    to Battambang jail. And my brother escaped from jail and they say, oh, we can come up
+    to his brother's. So then the news spread to me right away that my brother was escaping
+    and these people want to arrest me because I was a scapegoat. And they want to arrest
+    me. And they told me, you have to leave. And my mom said, well, you have to leave
+    then. You don't have to stay with us.
+    PR: So you went across the border to a camp in Thailand?
+    YY: Yeah.
+    Khmer Oral History Project
+    Minnesota Historical Society
+    PR: From that camp you got to Minnesota, then?
+    YY: No, I stayed in - - went back and forth, went back and forth. I went to they call old
+    camp, (Mak Moon camp) and then to kind of move around to (Nong Jamit camp) and
+    then move to -- I did not stay at (Nontang camp) very long, a few days a few nights. But I
+    was living in (Mak Moon) perhaps one year and then a new camp, Samit camp for - -
+    PR: How were the conditions of the camp, camps?
+    YY: Condition in the camps was not really good for me in the first time and I did not
+    have any money, any things to support my life. The first time, I have to, because there are
+    a lot of people come from Cambodia and get into Thailand buy goods from Thailand and
+    sell to Cambodia. So then I not know what to do. And then I think, oh, my mom gave me
+    some gold. And then I sold that gold. I got about seven hundred baths and I said maybe I
+    can use this money to build my business. Perhaps I can get into Thai village and buy
+    some stuff and sell to these people. Then I keep thinking about that and then I practiced
+    that. And I went to a Thai village and bought the rice from a Thai village and sell it to
+    Cambodia and made profits. And my money keep getting more and more than. Then I
+    keep buying different goods from the lowest to the expensive bicycle, recorders, and I
+    make money until 19 - - I got shot by the Thai robber. I got shot on my back here. And
+    then my older brother in Thailand right now said you shouldn't do that anymore because
+    it's very dangerous, because sometime people were killed by Thai robbers, and kill by
+    Thai soldiers. And some beat by the robbers, the gang bandit in Cambodia. So you don't
+    have to do that. Maybe you can stay in the camp with me.
+    PR: Did you do that?
+    YY: Yeah, I did that because –
+    PR: So how did you get out of the camp into the United States?
+    YY: I got married in 1980, and then I said I am not in that business anymore, and I
+    worked with (ARC). I found a way. Then I speak a little bit of English at that time, so I
+    learned from this people American Refugee Committee ... make friend with (Jean
+    Jachman) and she help me to buy a book and stuff. And one day I learn about my brother-in-
+    law. He wrote letter to my wife to, yeah, to my wife and to his older brother who is
+    also now in Minnesota. Oh, (Lon) is in Minnesota, at that time my older brother-in-law
+    was in (Khao I Dang) and my mother-in-law come back from Cambodia to visit us in the
+    camp. And accidentally my older brother-in-law came from (Khao I Dang) to visit us in
+    the camp and he met my wife and my mom, my mother-in-law. And then he talked to my
+    mother-in-law and told my mother-in-law, oh, (Lon) is in Minnesota, United States. And
+    I was approved by the INS - - I hope I can join him very soon and would you like to
+    come, would you please come. And my mother-in-law said, well, I have a youngest son
+    in Cambodia, and also your dad in Cambodia. I have to go back to Cambodia and bring
+    all these people. Then my mother-in-law went back to Cambodia and brought all of them
+    and they got to (Khao I Dang) and then I followed them later. I came to (Khao I Dang) in
+    Khmer Oral History Project
+    Minnesota Historical Society
+    1984, and about a month, we were recognized as legal refugees. And before that you have
+    to sneak under ground, live like a squirrel, live like a frog in the well.
+    PR: So, but you were then recognized as refugees in '84?
+    YY: No, we just sneak into the camp and be illegal in (Khao I Dang).
+    PR: Then how did you get the great kind of status to come to the United States?
+    YY: Then in 1986, United Nation high commissioner for refugee in Thailand say these
+    people could be interviewed...high commission refugee and Thailand say that, oh...these
+    people could be if they have agreement with the United States also, I don't know - - these
+    people classified as refugees so they could be interviewed by United States and these
+    people have relatives in United States. And my brother-in-law here works so hard with
+    Senator Rudy Boswitch and Senator Durenberger. And then he file a petition for us and
+    then we join them there.
+    PR: Okay. Do you like it here?
+    YY: Yeah.
+    PR: Do you like the life here?
+    YY: Yeah, I like very much.
+    PR: Do you ever think that you would like to go back to Cambodia?
+    YY: Well, to me, I have bad enough experience and now I am a citizen of United States.
+    So at some point I want to go back but not to live there, to visit my own people, to visit
+    the country.
+    PR: Do you feel more or less at home here now then?
+    YY: Yeah. I felt here is more like my home and Cambodia is my native country. But
+    because my trip, just come back from Cambodia, so - -
+    PR: You did?
+    YY: Yeah. I just come back from Cambodia, so I feel like I am not safe to go back.
+    PR: How do you find - - do you think things are not going well there, the U.N. has not
+    brought things under control?
+    YY: Well, I have no comment on that.
+    PR: Okay. But while you were there, you didn't feel completely safe, is that correct?
+    Khmer Oral History Project
+    Minnesota Historical Society
+    YY: Yeah, that's correct. Because everything is not set in good place, so. Everything is
+    not just - - even education is not there, sanitation is not there, social service is not there.
+    Administration is not there.
+    PR: Do you have any idea what is going to happen to your family that is over there in
+    Thailand?
+    YY: I hope they will join me very soon by the end of year because I file petition for them
+    already and they were approved by the regions INS in Nebraska. And I hope to be
+    interviewed by the end of this month, so I hope they will come to the United States very
+    soon.
+    PR: I hope so, too, Yoeuth. I really do. Thank you so much for taking part in the Khmer
+    Archives Project. I really appreciate your coming. I know talking about some of these
+    things is very hard, because it brings back some awful memories for you. But we do
+    appreciate it very much.
+    YY: Yes, that is my pleasure.
+    PR: Bye, bye. That is it.
+    Khmer Oral History Project
+    Minnesota Historical Society
+  transl: {}
+  fullrs: {}
+  find: 1121.pdf
+  dmaccess: {}
+  dmimage: {}
+  dmcreated: '2021-07-01'
+  dmmodified: '2021-07-01'
+  dmoclcno: {}
+  dmrecord: '1120'
+  restrictionCode: '1'
+  cdmfilesize: '511295'
+  cdmfilesizeformatted: 0.49 MB
+  cdmprintpdf: '0'
+  cdmhasocr: '0'
+  cdmisnewspaper: '0'
+  page: []
+  id: p16022coll548/1120
+id: p16022coll548/1121

--- a/spec/lib/mdl/queue_iiif_search_processing_spec.rb
+++ b/spec/lib/mdl/queue_iiif_search_processing_spec.rb
@@ -4,43 +4,75 @@ require_relative '../../../lib/mdl/queue_iiif_search_processing'
 module MDL
   describe QueueIiifSearchProcessing do
     describe '.format' do
-      context 'when the primary document has a transcription' do
-        let(:document) do
-          {
-            'id' => 'pch/1224',
-            'transc' => 'foo'
-          }
+      let(:document) do
+        YAML.load_file(
+          File.join(Rails.root, 'spec', 'fixtures', 'contentdm', filename)
+        )
+      end
+
+      context 'with an audio playlist document' do
+        let(:filename) { 'audio_playlist.yml' }
+
+        it 'does not queue the IiifSearchProcessingWorker' do
+          expect(IiifSearchProcessingWorker).to_not receive(:perform_async)
+          described_class.format(document)
         end
+      end
+
+      context 'with an audio document' do
+        let(:filename) { 'audio.yml' }
+
+        it 'does not queue the IiifSearchProcessingWorker' do
+          expect(IiifSearchProcessingWorker).to_not receive(:perform_async)
+          described_class.format(document)
+        end
+      end
+
+      context 'with an image document that has a transcription' do
+        let(:filename) { 'image_with_transc.yml' }
 
         it 'queues the IiifSearchProcessingWorker' do
           expect(IiifSearchProcessingWorker).to receive(:perform_async)
-            .with('pch:1224')
+            .with('p16022coll31:14')
           QueueIiifSearchProcessing.format(document)
         end
       end
 
-      context 'when the primary document does not have a transcription' do
-        let(:document) do
-          { 'id' => 'abc/123' }
+      context 'with a multi-page text document' do
+        let(:filename) { 'multipage_text.yml' }
+
+        it 'queues the IiifSearchProcessingWorker' do
+          expect(IiifSearchProcessingWorker).to receive(:perform_async)
+            .with('nfh:806')
+          QueueIiifSearchProcessing.format(document)
         end
+      end
+
+      context 'with a single-page text document' do
+        let(:filename) { 'single_page_text.yml' }
+
+        it 'queues the IiifSearchProcessingWorker' do
+          expect(IiifSearchProcessingWorker).to receive(:perform_async)
+            .with('p16022coll73:30')
+          QueueIiifSearchProcessing.format(document)
+        end
+      end
+
+      context 'with a video document' do
+        let(:filename) { 'video.yml' }
 
         it 'does not queue the IiifSearchProcessingWorker' do
           expect(IiifSearchProcessingWorker).to_not receive(:perform_async)
-          QueueIiifSearchProcessing.format(document)
+          described_class.format(document)
         end
+      end
 
-        context 'but one of the sub-pages has a transcription' do
-          let(:document) do
-            {
-              'id' => 'pch/1224',
-              'page' => [{ 'transc' => 'foo' }]
-            }
-          end
-          it 'queues the IiifSearchProcessingWorker' do
-            expect(IiifSearchProcessingWorker).to receive(:perform_async)
-              .with('pch:1224')
-            QueueIiifSearchProcessing.format(document)
-          end
+      context 'with an video playlist document' do
+        let(:filename) { 'video_playlist.yml' }
+
+        it 'does not queue the IiifSearchProcessingWorker' do
+          expect(IiifSearchProcessingWorker).to_not receive(:perform_async)
+          described_class.format(document)
         end
       end
     end


### PR DESCRIPTION
Until now, we've treated any document with a transcription as
"IIIF-search material". This isn't correct, though, because audio and
visual media have transcriptions and are doomed to fail in the IIIF
search indexing pipeline. This change better identifies documents as
candidates for IIIF search processing.