### PR TITLE
Selectively index entire collection when date omitted

### DIFF
--- a/app/controllers/indexing_controller.rb
+++ b/app/controllers/indexing_controller.rb
@@ -25,7 +25,7 @@ class IndexingController < ApplicationController
   end
 
   def create
-    args = { set_specs: [params.require(:collection)] }
+    args = { set_specs: [params.require(:collection)], from: '1970-01-01' }
     if params[:date].present?
       args[:from] = Date.parse(params[:date]).iso8601
     end

--- a/spec/controllers/indexing_controller_spec.rb
+++ b/spec/controllers/indexing_controller_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+describe IndexingController do
+  describe 'POST to #create' do
+    let(:params) do
+      {
+        collection: 'pokemon',
+        date: date
+      }
+    end
+    let(:etl) { instance_double(MDL::ETL) }
+
+    before do
+      user = User.create!(
+        email: 'fred@example.com',
+        password: 'password',
+        user_roles: ['admin']
+      )
+      sign_in user
+      allow(MDL::ETL).to receive(:new).and_return(etl)
+    end
+
+    context 'when a date is provided' do
+      let(:date) { '2022-01-03' }
+
+      it 'forwards the date to the ETL' do
+        expect(etl).to receive(:run).with(
+          set_specs: ['pokemon'],
+          from: date
+        )
+        post :create, params: params
+      end
+    end
+
+    context 'when no date is provided' do
+      let(:date) { '' }
+
+      it 'forwards a default date to the ETL' do
+        expect(etl).to receive(:run).with(
+          set_specs: ['pokemon'],
+          from: '1970-01-01'
+        )
+        post :create, params: params
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -51,6 +51,7 @@ RSpec.configure do |config|
 
   config.include FactoryGirl::Syntax::Methods
   config.include Devise::Test::IntegrationHelpers, type: :request
+  config.include Devise::Test::ControllerHelpers, type: :controller
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"


### PR DESCRIPTION
This change causes the unix epoch to be used as a default date for
selective indexing when none is provided by the user. With this, the
behavior aligns with the copy on the page, and should no longer be
confusing.

Fixes #206 