### PR TITLE
Disable turbolinks cache on pages with BL range limit chart

### DIFF
--- a/app/views/blacklight_range_limit/_range_limit_panel.html.erb
+++ b/app/views/blacklight_range_limit/_range_limit_panel.html.erb
@@ -89,3 +89,7 @@
   <% end %>
 </div>
 
+<% content_for(:head) do %>
+  <!-- turbolinks' cache doesn't work with the Flot chart -->
+  <meta name="turbolinks-cache-control" content="no-cache">
+<% end %>


### PR DESCRIPTION
The Turbolinks cache doesn't work well with the Flot chart of the search
result dates. The reason for the issue is that creating the Flot chart
manipulates the DOM, so that when someone clicks the back button to
return to a page that would have one of these charts, the DOM elements
that the blacklight_range_limit JavaScript depends on to create the
chart no longer exist.

The solution here is to disable the Turbolinks cache on pages that
render the date range chart (basically, just the search results page).
The tradeoff is that using the browser back button to navigate back to
the search results page will trigger a full page load. In production,
the query results are cached in Redis, so hopefully it's not too much of
a performance issue.

Fixes #205 