### PR TITLE
Fix image download aspect ratio

### DIFF
--- a/lib/mdl/borealis_image.rb
+++ b/lib/mdl/borealis_image.rb
@@ -11,8 +11,8 @@ module MDL
 
     def downloads
       [
-        { src: "http://cdm16022.contentdm.oclc.org/digital/iiif/#{collection}/#{id}/full/!150,150/0/default.jpg", label: '(150 x 150)' },
-        { src: "http://cdm16022.contentdm.oclc.org/digital/iiif/#{collection}/#{id}/full/!800,800/0/default.jpg", label: '(800 x 800)' }
+        { src: "http://cdm16022.contentdm.oclc.org/digital/iiif/#{collection}/#{id}/full/150,/0/default.jpg", label: '(150w)' },
+        { src: "http://cdm16022.contentdm.oclc.org/digital/iiif/#{collection}/#{id}/full/800,/0/default.jpg", label: '(800w)' }
       ]
     end
 

--- a/spec/lib/mdl/borealis_image_spec.rb
+++ b/spec/lib/mdl/borealis_image_spec.rb
@@ -18,8 +18,8 @@ module MDL
 
     it 'correctly identifies its downloads' do
       expect(image.downloads).to eq [
-        { src: "http://cdm16022.contentdm.oclc.org/digital/iiif/foo/21/full/!150,150/0/default.jpg", label: '(150 x 150)' },
-        { src: "http://cdm16022.contentdm.oclc.org/digital/iiif/foo/21/full/!800,800/0/default.jpg", label: '(800 x 800)' }
+        { src: "http://cdm16022.contentdm.oclc.org/digital/iiif/foo/21/full/150,/0/default.jpg", label: '(150w)' },
+        { src: "http://cdm16022.contentdm.oclc.org/digital/iiif/foo/21/full/800,/0/default.jpg", label: '(800w)' }
       ]
     end
 


### PR DESCRIPTION
Looks like we can't force a resize to a given width and height, but we can specify a width. With this, we'll have the aspect ratio preserved. Also updates the download link label to reflect the changes:

old: `(150 x 150)`
new: `(150w)`

Fixes #159 