### PR TITLE
Only write a crontab on the job servers

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -56,6 +56,8 @@ set :keep_releases, 2
 # our database. No need to run from the indexing server (:job)
 set :migration_role, [:app]
 
+set :whenever_roles, [:job]
+
 set :passenger_restart_with_touch, true
 
 namespace :deploy do


### PR DESCRIPTION
This is important because the main indexing cron job generates a JSON
blob of config data to pass to the indexing jobs. This contains the URL
for Solr, which is different on the app server than it is on the job
server (loopback vs DNS). So if we generate the config on the app server
but run the jobs on the job server, we won't have a usable URL for Solr
and the jobs will fail.