### PR TITLE
Update setup instructions and fix webpack-dev-server executable

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,7 +1,7 @@
 RAILS_ROOT_URL=http://localhost:3000
 RAILS_ENV=development
-REDIS_URL=redis://redis:6379
-REDIS_CACHE_URL=redis://redis_cache:6379/0/cache
+REDIS_URL=redis://localhost:6379
+REDIS_CACHE_URL=redis://localhost:6379/0/cache
 REDIS_PROVIDER=REDIS_URL
 SOLR_BASE_URL=http://solr:8983
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN curl -sL https://deb.nodesource.com/setup_12.x | bash \
   && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
   && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
   && apt-get install apt-transport-https -y \
-  && apt-get update && apt-get install -y yarn
+  && apt-get update && apt-get install -y python2 g++ make yarn
 
 # For Capybara
 #RUN apt-get install -y -qq libqt4-dev libqtwebkit-dev

--- a/README.md
+++ b/README.md
@@ -17,11 +17,12 @@ Copy the .env-example file
 cp .env-example .env
 ```
 
-Install Ruby 2.4 via [RVM](http://rvm.io/) or [rbenv](https://github.com/rbenv/rbenv)
+Install Ruby 3.1.2 via [rbenv](https://github.com/rbenv/rbenv)
 
-(rvm instructions)
 ```bash
-rvm install ruby-2.4
+brew install rbenv ruby-build
+rbenv init
+rbenv install 3.1.2
 ```
 
 Install MySQL and Redis clients, as well as geckodriver for system tests run via Selenium.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,12 @@ Start Sidekiq
 ./start_sidekiq.sh 'default -q iiif_search -q critical,2'
 ```
 
-[Ingest some content](https://github.com/Minitex/mdl_search/wiki/Development-Environment-Setup#ingest-some-content)
+Ingest some content
+
+```bash
+bundle exec rake 'mdl_ingester:collection[p15160coll13]'
+bundle exec rake 'mdl_ingester:collection[p16022coll10]'
+```
 
 ## Logging in
 
@@ -78,7 +83,7 @@ Enter an interactive session with the application (must be running in another ta
 
 ## Troubleshooting
 
-* [MySQL] If you run into issues with the database, try nuking the db volumes and restarting:
+* [MySQL] If you run into issues with the database, try removing and recreating the db volumes:
   * `$ docker-compose down -v; docker-compose up`
 
 ## Updating the React Component

--- a/bin/webpack-dev-server
+++ b/bin/webpack-dev-server
@@ -21,7 +21,7 @@ def args(key)
 end
 
 begin
-  dev_server = YAML.load_file(CONFIG_FILE)["development"]["dev_server"]
+  dev_server = YAML.load_file(CONFIG_FILE, aliases: true)["development"]["dev_server"]
 
   DEV_SERVER_HOST = "http#{"s" if args('--https') || dev_server["https"]}://#{args('--host') || dev_server["host"]}:#{args('--port') || dev_server["port"]}"
 


### PR DESCRIPTION
Updates the README with the correct Ruby version, removes RVM install instructions in favor of RVM, and fixes an issue with loading a YAML config file in ./bin/webpack-dev-server