### PR TITLE
Support SSL for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ public/uv
 
 mdl-solr-core
 .env
+/certs/*

--- a/README.md
+++ b/README.md
@@ -31,6 +31,37 @@ Install MySQL and Redis clients, as well as geckodriver for system tests run via
 brew install mysql@5.7 redis geckodriver
 ```
 
+Install Nginx and mkcert (for local SSL)
+
+```bash
+brew install nginx
+brew install mkcert
+brew install nss # If you use Firefox
+```
+
+Install a local SSL cert
+
+```bash
+mkcert -install # Will ask for sudo password
+
+mkcert mdl.devlocal
+
+mkdir -p certs
+mv mdl.devlocal* ./certs/
+```
+
+Install the Nginx config
+
+```bash
+./bin/install_nginx_conf
+```
+
+Start Nginx
+
+```bash
+sudo brew services start nginx
+```
+
 Install Node via [NVM](https://github.com/nvm-sh/nvm) (or preferred alternative)
 
 ```bash
@@ -70,7 +101,7 @@ Start the rails server
 bundle exec rails s
 ```
 
-You can login by visiting http://localhost:3000/users/sign_in
+You can login by visiting https://mdl.devlocal/users/sign_in
 
 username: local@example.com
 password: password

--- a/bin/install_nginx_conf
+++ b/bin/install_nginx_conf
@@ -1,0 +1,18 @@
+#!/usr/bin/env ruby
+
+require 'fileutils'
+require 'erb'
+
+app_root = File.expand_path('../..', __FILE__)
+config_template_path = File.join(app_root, 'config/local-nginx.conf.erb')
+nginx_servers_path = '/usr/local/etc/nginx/servers'
+nginx_config_path = File.join(nginx_servers_path, 'mdl.conf')
+
+FileUtils.mkdir_p(nginx_servers_path)
+
+File.open(nginx_config_path, 'w+') do |f|
+  template = IO.read(config_template_path)
+  f << ERB.new(template).result_with_hash(app_root: app_root)
+end
+
+puts 'Nginx config is installed ✅'

--- a/bin/webpack-dev-server
+++ b/bin/webpack-dev-server
@@ -23,7 +23,8 @@ end
 begin
   dev_server = YAML.load_file(CONFIG_FILE, aliases: true)["development"]["dev_server"]
 
-  DEV_SERVER_HOST = "http#{"s" if args('--https') || dev_server["https"]}://#{args('--host') || dev_server["host"]}:#{args('--port') || dev_server["port"]}"
+  # DEV_SERVER_HOST = "http#{"s" if args('--https') || dev_server["https"]}://#{args('--host') || dev_server["host"]}:#{args('--port') || dev_server["port"]}"
+  DEV_SERVER_HOST = 'https://mdl.devlocal'
 
 rescue Errno::ENOENT, NoMethodError
   puts "Webpack dev_server configuration not found in #{CONFIG_FILE}."

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -73,4 +73,6 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+
+  config.hosts << 'mdl.devlocal'
 end

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -5,5 +5,7 @@ Rails.application.config.session_store(
   key: '_mdl_search_session',
   domain: :all,
   same_site: :none,
+  secure: true,
+  expire_after: 14.days,
   tld_length: 2
 )

--- a/config/local-nginx.conf.erb
+++ b/config/local-nginx.conf.erb
@@ -1,0 +1,61 @@
+upstream mdl_app {
+    server unix://<%= app_root %>/tmp/sockets/puma.sock;
+}
+
+upstream webpack_dev_server {
+    server 0.0.0.0:8080;
+}
+
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    '' close;
+}
+
+server {
+    listen 80;
+    server_name mdl.devlocal;
+    return 301 https://mdl.devlocal$request_uri;
+}
+
+server {
+    listen       443 ssl;
+    server_name  mdl.devlocal;
+
+    ssl_certificate      <%= app_root %>/certs/mdl.devlocal.pem;
+    ssl_certificate_key  <%= app_root %>/certs/mdl.devlocal-key.pem;
+
+    location /packs/ {
+        proxy_pass http://webpack_dev_server;
+        proxy_set_header Host $host;
+    }
+
+    location / {
+        proxy_buffer_size          128k;
+        proxy_buffers              4 256k;
+        proxy_busy_buffers_size    256k;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header Host $host;
+
+        # If the file exists as a static file serve it directly without
+        # running all the other rewrite tests on it
+        if (-f $request_filename) {
+            break;
+        }
+
+        if (!-f $request_filename) {
+            proxy_pass http://mdl_app;
+            break;
+        }
+    }
+
+    location /sockjs-node/ {
+        proxy_pass http://webpack_dev_server;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+    }
+
+    # path for static files
+    root <%= app_root %>/public;
+}

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -10,7 +10,12 @@ threads min_threads_count, max_threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port        ENV.fetch("PORT") { 3000 }
+# port        ENV.fetch("PORT") { 3000 }
+socket_file = File.expand_path(
+  File.join('..', '..', 'tmp', 'sockets', 'puma.sock'),
+  __FILE__
+)
+bind "unix://#{socket_file}"
 
 # Specifies the `environment` that Puma will run in.
 #

--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -16,7 +16,8 @@ module.exports = merge(sharedConfig, {
   },
 
   devServer: {
-    clientLogLevel: 'none',
+    clientLogLevel: 'info',
+    disableHostCheck: true,
     https: settings.dev_server.https,
     host: settings.dev_server.host,
     port: settings.dev_server.port,
@@ -28,5 +29,6 @@ module.exports = merge(sharedConfig, {
     watchOptions: {
       ignored: /node_modules/,
     },
+    public: 'mdl.devlocal:443'
   },
 });


### PR DESCRIPTION
Since we're setting 'SameSite: None' on our session cookie, we must also set the Secure flag or it will be ignored by Chrome. In order to set the Secure flag, we must be using SSL. This change adds support for setting up SSL on your local development environment.

Getting this up and running will require following the new steps in the README and then rebuilding your webpacker container:

```shell
docker stop mdl_search_webpacker_1
docker ps --all --quiet --filter name=mdl_search_webpacker  | xargs docker rm
docker images mdl_search_webpacker:latest --quiet | xargs docker rmi
docker-compose build webpacker
docker-compose up -d webpacker
```