### PR TITLE
Provide basic support for embedded images in exhibits

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -156,8 +156,9 @@ class CatalogController < ApplicationController
     # Spotlight additions
     config.show.oembed_field = :oembed_url_ssm
     config.show.partials.insert(1, :oembed)
-    config.show.tile_source_field = :content_metadata_image_iiif_info_ssm
-    config.show.partials.insert(1, :openseadragon)
+    config.show.tile_source_field = :image_uri_ssi
+    config.index.tile_source_field = :image_uri_ssi
+    config.view.embed.partials = ['embedded']
     config.document_solr_path = 'get'
     config.document_unique_id_param = 'ids'
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -158,7 +158,6 @@ class CatalogController < ApplicationController
     config.show.partials.insert(1, :oembed)
     config.show.tile_source_field = :image_uri_ssi
     config.index.tile_source_field = :image_uri_ssi
-    config.view.embed.partials = ['embedded']
     config.document_solr_path = 'get'
     config.document_unique_id_param = 'ids'
 

--- a/app/helpers/mdl_blacklight_helper.rb
+++ b/app/helpers/mdl_blacklight_helper.rb
@@ -41,8 +41,11 @@ module MDLBlacklightHelper
   end
 
   def link_to_document(doc, field_or_opts = nil, opts = { counter: nil })
-    if field_or_opts.is_a? Hash
+    case field_or_opts
+    when Hash
       opts = field_or_opts
+    when String
+      return document_show_link(document: doc, label: field_or_opts, **opts)
     else
       field = field_or_opts
     end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -59,6 +59,12 @@ class SolrDocument
     OaiSet.sets_for(self)
   end
 
+  def image_url
+    asset = MDL::BorealisDocument.new(document: self._source).assets.first
+    return unless asset.is_a?(MDL::BorealisImage)
+    asset.src
+  end
+
   private
 
   def mlt_values

--- a/app/views/catalog/_embedded_still_image.html.erb
+++ b/app/views/catalog/_embedded_still_image.html.erb
@@ -1,0 +1,3 @@
+<div class="embedded">
+  <%= image_tag document.image_url, class: "embedded-image" %>
+</div>

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -25,7 +25,7 @@ set :repo_url, 'git@github.com:UMNLibraries/mdl_search.git'
 # set :linked_files, %w{config/database.yml}
 
 # Default value for linked_dirs is []
-# set :linked_dirs, %w{bin log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system}
+set :linked_dirs, %w(log public/uploads)
 
 # Default value for default_env is {}
 # set :default_env, { path: "/opt/ruby/bin:$PATH" }
@@ -36,8 +36,6 @@ set :repo_url, 'git@github.com:UMNLibraries/mdl_search.git'
 set :deploy_to, '/swadm/var/www/mdl'
 
 set :ssh_options, { user: 'swadm', forward_agent: true }
-
-append :linked_dirs, "log"
 
 set :rails_env, "production"
 

--- a/lib/mdl/borealis_image.rb
+++ b/lib/mdl/borealis_image.rb
@@ -1,8 +1,7 @@
 module MDL
-
-  class BorealisImage <  BorealisAsset
+  class BorealisImage < BorealisAsset
     def src
-      "/contentdm-images/info?id=#{collection}:#{id}"
+      "https://cdm16022.contentdm.oclc.org/iiif/2/#{collection}:#{id}/full/full/0/default.jpg"
     end
 
     def type
@@ -11,8 +10,8 @@ module MDL
 
     def downloads
       [
-        { src: "http://cdm16022.contentdm.oclc.org/digital/iiif/#{collection}/#{id}/full/150,/0/default.jpg", label: '(150w)' },
-        { src: "http://cdm16022.contentdm.oclc.org/digital/iiif/#{collection}/#{id}/full/800,/0/default.jpg", label: '(800w)' }
+        { src: "https://cdm16022.contentdm.oclc.org/digital/iiif/#{collection}/#{id}/full/150,/0/default.jpg", label: '(150w)' },
+        { src: "https://cdm16022.contentdm.oclc.org/digital/iiif/#{collection}/#{id}/full/800,/0/default.jpg", label: '(800w)' }
       ]
     end
 

--- a/spec/lib/mdl/borealis_image_spec.rb
+++ b/spec/lib/mdl/borealis_image_spec.rb
@@ -9,7 +9,8 @@ module MDL
     end
 
     it 'correctly identifies its src' do
-      expect(image.src).to eq '/contentdm-images/info?id=foo:21'
+      expected_src = 'https://cdm16022.contentdm.oclc.org/iiif/2/foo:21/full/full/0/default.jpg'
+      expect(image.src).to eq expected_src
     end
 
     it 'correctly identifies its type' do
@@ -18,8 +19,8 @@ module MDL
 
     it 'correctly identifies its downloads' do
       expect(image.downloads).to eq [
-        { src: "http://cdm16022.contentdm.oclc.org/digital/iiif/foo/21/full/150,/0/default.jpg", label: '(150w)' },
-        { src: "http://cdm16022.contentdm.oclc.org/digital/iiif/foo/21/full/800,/0/default.jpg", label: '(800w)' }
+        { src: 'https://cdm16022.contentdm.oclc.org/digital/iiif/foo/21/full/150,/0/default.jpg', label: '(150w)' },
+        { src: 'https://cdm16022.contentdm.oclc.org/digital/iiif/foo/21/full/800,/0/default.jpg', label: '(800w)' }
       ]
     end
 


### PR DESCRIPTION
This adds a very simple partial that will be picked up by Blacklight's rendering pipeline when an image is embedded in an exhibit. Somehow in the course of upgrading Blacklight and Spotlight, image rendering stopped working.