### PR TITLE
Persist existing query when presenting available facet values

### DIFF
--- a/app/overrides/spotlight/controller_override.rb
+++ b/app/overrides/spotlight/controller_override.rb
@@ -4,7 +4,12 @@ module Spotlight
       if current_exhibit
         exhibit_search_facet_path(*args, **kwargs)
       else
-        main_app.facet_catalog_url(*args, **kwargs)
+        opts = search_state
+           .to_h
+           .merge(only_path: true)
+           .merge(kwargs)
+           .except(:page)
+        main_app.facet_catalog_url(*args, **opts)
       end
     end
 


### PR DESCRIPTION
The link to show all available values for a given facet now includes the existing search context. This ensures that any parameters that narrowed the search results are applied to the facet query as well.

Fixes #270 