### PR TITLE
Defend against bots when managing pagination

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -109,6 +109,7 @@ class CatalogController < ApplicationController
   def manage_pagination
     return if flash.key?(:pagination_managed)
     per_page = params.fetch(:per_page) { return }
+    return unless request.referrer
 
     per_page = per_page.to_i
     prev_page, previous_per_page = parse_referrer_pagination_params

--- a/spec/requests/catalog_pagination_spec.rb
+++ b/spec/requests/catalog_pagination_spec.rb
@@ -118,4 +118,13 @@ describe 'Catalog#index pagination' do
       expect(flash.key?(:pagination_managed)).to eq(false)
     end
   end
+
+  context 'no referrer' do
+    let(:target_per_page) { '25' }
+    let(:headers) { {} }
+
+    it 'does not redirect' do
+      expect(response).to have_http_status(:ok)
+    end
+  end
 end


### PR DESCRIPTION
Bots don't send a referer header, so we can stop trying to manage pagination for them. This is currently manifesting as an exception, but I don't believe it's affecting real users.

[Sentry error](https://minitex.sentry.io/issues/3906937473/events/c2e8dac124214c10acc59827a29ab55d)