### PR TITLE
Fix error with searching within exhibits

### DIFF
--- a/app/components/search_bar_component.html.erb
+++ b/app/components/search_bar_component.html.erb
@@ -1,4 +1,4 @@
-<%= form_tag search_catalog_url, method: :get, class: 'search-query-form form-inline', role: 'search' do %>
+<%= form_tag url, method: :get, class: 'search-query-form form-inline', role: 'search' do %>
   <% if params[:search_field] != 'advanced' %>
     <%= render Blacklight::HiddenSearchStateComponent.new(params: @params) %>
   <% end %>

--- a/app/components/search_bar_component.rb
+++ b/app/components/search_bar_component.rb
@@ -1,4 +1,6 @@
 class SearchBarComponent < Blacklight::SearchBarComponent
+  attr_reader :url
+
   def advanced_search_enabled?
     false
   end


### PR DESCRIPTION
The search bar component template was using a route helper that wasn't compatible with the exhibit context, and so searches were being routed to a path that matched a route where the `/catalog` segment was interpreted as an exhibit ID. This caused an exception because the app was trying to look up an exhibit having the slug "catalog".

This updates the route in the template to be compatible with both the exhibit and catalog contexts.

Fixes #280 