### PR TITLE
Fix doubled facets on advanced search results page

### DIFF
--- a/app/controllers/advanced_controller.rb
+++ b/app/controllers/advanced_controller.rb
@@ -90,6 +90,7 @@ class AdvancedController < BlacklightAdvancedSearch::AdvancedController
       field.sort = 'index'
       field.item_presenter = FacetItemPresenter
       field.item_component = FacetItemComponent
+      field.component = Blacklight::FacetFieldListComponent
     end
     config.add_facet_field 'type_ssi' do |field|
       field.label = 'Type'
@@ -97,6 +98,7 @@ class AdvancedController < BlacklightAdvancedSearch::AdvancedController
       field.sort = 'index'
       field.item_presenter = FacetItemPresenter
       field.item_component = FacetItemComponent
+      field.component = Blacklight::FacetFieldListComponent
     end
     config.add_facet_field 'physical_format_ssi' do |field|
       field.label = 'Physical Format'
@@ -106,6 +108,7 @@ class AdvancedController < BlacklightAdvancedSearch::AdvancedController
       field.sort = 'index'
       field.item_presenter = FacetItemPresenter
       field.item_component = FacetItemComponent
+      field.component = Blacklight::FacetFieldListComponent
     end
     config.add_facet_field 'formal_subject_ssim' do |field|
       field.label = 'Subject Headings'
@@ -114,6 +117,7 @@ class AdvancedController < BlacklightAdvancedSearch::AdvancedController
       field.sort = 'index'
       field.item_presenter = FacetItemPresenter
       field.item_component = FacetItemComponent
+      field.component = Blacklight::FacetFieldListComponent
     end
     config.add_facet_field 'rights_status_ssi' do |field|
       field.label = 'Rights Status'
@@ -121,6 +125,7 @@ class AdvancedController < BlacklightAdvancedSearch::AdvancedController
       field.sort = 'index'
       field.item_presenter = FacetItemPresenter
       field.item_component = FacetItemComponent
+      field.component = Blacklight::FacetFieldListComponent
     end
     config.add_facet_field 'collection_name_ssi' do |field|
       field.label = 'Contributor'
@@ -129,6 +134,7 @@ class AdvancedController < BlacklightAdvancedSearch::AdvancedController
       field.sort = 'index'
       field.item_presenter = FacetItemPresenter
       field.item_component = FacetItemComponent
+      field.component = Blacklight::FacetFieldListComponent
     end
     config.add_facet_field 'dat_ssim' do |field|
       field.label = 'Date Created'
@@ -136,6 +142,7 @@ class AdvancedController < BlacklightAdvancedSearch::AdvancedController
       field.range = true
       field.item_presenter = FacetItemPresenter
       field.item_component = FacetItemComponent
+      field.component = Blacklight::FacetFieldListComponent
     end
   end
 end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -255,6 +255,7 @@ class CatalogController < ApplicationController
       field.label = 'Topic'
       field.item_presenter = FacetItemPresenter
       field.item_component = FacetItemComponent
+      field.component = Blacklight::FacetFieldListComponent
     end
     config.add_facet_field 'type_ssi' do |field|
       field.label = 'Type'
@@ -263,6 +264,7 @@ class CatalogController < ApplicationController
       field.limit = 10
       field.item_presenter = FacetItemPresenter
       field.item_component = FacetItemComponent
+      field.component = Blacklight::FacetFieldListComponent
     end
     config.add_facet_field 'physical_format_ssi' do |field|
       field.label = 'Physical Format'
@@ -273,6 +275,7 @@ class CatalogController < ApplicationController
       field.limit = 5
       field.item_presenter = FacetItemPresenter
       field.item_component = FacetItemComponent
+      field.component = Blacklight::FacetFieldListComponent
     end
     config.add_facet_field 'dat_ssim' do |field|
       field.label = 'Date Created'
@@ -280,6 +283,7 @@ class CatalogController < ApplicationController
       field.range = true
       field.item_presenter = FacetItemPresenter
       field.item_component = FacetItemComponent
+      field.component = Blacklight::FacetFieldListComponent
     end
     config.add_facet_field 'placename_ssim' do |field|
       field.label = 'Location'
@@ -289,6 +293,7 @@ class CatalogController < ApplicationController
       field.index = true
       field.item_presenter = FacetItemPresenter
       field.item_component = FacetItemComponent
+      field.component = Blacklight::FacetFieldListComponent
     end
     config.add_facet_field 'formal_subject_ssim' do |field|
       field.label = 'Subject Headings'
@@ -299,6 +304,7 @@ class CatalogController < ApplicationController
       field.index = true
       field.item_presenter = FacetItemPresenter
       field.item_component = FacetItemComponent
+      field.component = Blacklight::FacetFieldListComponent
     end
     config.add_facet_field 'collection_name_ssi' do |field|
       field.label = 'Contributor'
@@ -320,6 +326,7 @@ class CatalogController < ApplicationController
       field.collapse = false
       field.item_presenter = FacetItemPresenter
       field.item_component = FacetItemComponent
+      field.component = Blacklight::FacetFieldListComponent
     end
 
     # Have BL send all facet field names to Solr, which has been the default

--- a/app/helpers/facets_helper.rb
+++ b/app/helpers/facets_helper.rb
@@ -32,7 +32,7 @@ module FacetsHelper
   # @param [Array<String>] fields
   # @param [Hash] options
   # @return String
-  def render_facet_partials fields = facet_field_names, options = {}
+  def render_facet_partials(fields = facet_field_names, options = {})
     safe_join(facets_from_request(fields, options.delete(:response)).map do |display_facet|
       render_facet_limit(display_facet, options)
     end.compact, "\n")


### PR DESCRIPTION
In the shuffle of the Blacklight upgrade, some configuration changes were missed that was causing search facets to show up twice on the SRP. Adding the missing configuration fixes that, with the happy side effect of eliminating a bunch of deprecation warnings.

Fixes #282 