### PR TITLE
Exhibit search error

### DIFF
--- a/app/components/search_bar_component.html.erb
+++ b/app/components/search_bar_component.html.erb
@@ -1,6 +1,6 @@
 <%= form_tag url, method: :get, class: 'search-query-form form-inline', role: 'search' do %>
   <% if params[:search_field] != 'advanced' %>
-    <%= render Blacklight::HiddenSearchStateComponent.new(params: @params) %>
+    <%= render Blacklight::HiddenSearchStateComponent.new(params: hidden_field_params) %>
   <% end %>
   <div class="input-group">
     <% if search_fields.length > 1 %>

--- a/app/components/search_bar_component.rb
+++ b/app/components/search_bar_component.rb
@@ -1,6 +1,10 @@
 class SearchBarComponent < Blacklight::SearchBarComponent
   attr_reader :url
 
+  def hidden_field_params
+    @params.except(:exhibit_id)
+  end
+
   def advanced_search_enabled?
     false
   end

--- a/app/controllers/advanced_controller.rb
+++ b/app/controllers/advanced_controller.rb
@@ -142,7 +142,6 @@ class AdvancedController < BlacklightAdvancedSearch::AdvancedController
       field.range = true
       field.item_presenter = FacetItemPresenter
       field.item_component = FacetItemComponent
-      field.component = Blacklight::FacetFieldListComponent
     end
   end
 end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -283,7 +283,6 @@ class CatalogController < ApplicationController
       field.range = true
       field.item_presenter = FacetItemPresenter
       field.item_component = FacetItemComponent
-      field.component = Blacklight::FacetFieldListComponent
     end
     config.add_facet_field 'placename_ssim' do |field|
       field.label = 'Location'

--- a/app/views/shared/_search_block.erb
+++ b/app/views/shared/_search_block.erb
@@ -3,7 +3,7 @@
     <div class="row">
       <div class="col-sm-6 col-lg-9">
         <%= render(SearchBarComponent.new(
-          url: search_action_url,
+          url: main_app.search_catalog_url,
           params: search_state.params_for_search.except(:qt),
           autocomplete_path: search_action_path(controller: :catalog, action: :suggest)
         )) %>


### PR DESCRIPTION
**Don't scope search bar to current exhibit**

The search bar was searching in the context of the current exhibit, and
that is not desired. This updates that URL to be the main, unscoped
search URL.

Fixes #280 

**Fix regression on date range facet**

In fixing the doubled facets issue (#282), I introduced a regression
with the Date Created facet. My changes to facet field configuration
caused the Date Created facet to itemize the dates rather than display
the histogram. This fixes it.