### PR TITLE
Fix pagination management when referrer has no query string

### DIFF
--- a/spec/requests/catalog_pagination_spec.rb
+++ b/spec/requests/catalog_pagination_spec.rb
@@ -9,10 +9,9 @@ describe 'Catalog#index pagination' do
       q: ''
     }
   end
+  let(:referrer) { "https://mdl.devlocal/catalog?#{referrer_page_params}" }
   let(:headers) do
-    {
-      'HTTP_REFERER' => "https://mdl.devlocal/catalog?#{referrer_page_params}"
-    }
+    { 'HTTP_REFERER' => referrer }
   end
 
   def assert_redirect(page:)
@@ -112,6 +111,16 @@ describe 'Catalog#index pagination' do
   context 'when no referrer page params are provided' do
     let(:referrer_page_params) { '' }
     let(:target_per_page) { '2' }
+
+    it 'does not redirect' do
+      expect(response).to have_http_status(:ok)
+      expect(flash.key?(:pagination_managed)).to eq(false)
+    end
+  end
+
+  context 'referrer has no query string' do
+    let(:referrer) { 'https://mdl.devlocal/' }
+    let(:target_per_page) { '100' }
 
     it 'does not redirect' do
       expect(response).to have_http_status(:ok)


### PR DESCRIPTION
The code that manages pagination of the catalog wasn't handling the case where there is a referer header but it does not have a query string. This was causing an exception while parsing the non existent value. This change adds handling for that scenario.

Fixes #290 