### PR TITLE
Fix formatting of metadata details

### DIFF
--- a/app/javascript/react-citation/cite-details-field-value.js
+++ b/app/javascript/react-citation/cite-details-field-value.js
@@ -39,7 +39,7 @@ export default class DetailsFieldValue extends React.Component {
   }
 
   render() {
-    return <span>{this._field()}{this._delimiter()}</span>
+    return <div>{this._field()}{this._delimiter()}</div>
   }
 }
 

--- a/lib/mdl/cite_details.rb
+++ b/lib/mdl/cite_details.rb
@@ -114,7 +114,7 @@ module MDL
         {key: 'state_ssi', label: 'State or Province', facet: true},
         {key: 'country_ssi', label: 'Country', facet: true},
         {key: 'geographic_feature_ssim', label: 'Geographic Feature', facet: true},
-        {key: 'geonam_ssi', label: 'GeoNames URI', facet: true},
+        {key: 'geonam_ssi', label: 'GeoNames URI'},
         {key: 'language_ssi', label: 'Language'},
         {key: 'local_identifier_ssi', label: 'Local Identifier'},
         {key: 'identifier_ssi', label: 'MDL Identifier'},

--- a/spec/lib/mdl/cite-details_spec.rb
+++ b/spec/lib/mdl/cite-details_spec.rb
@@ -98,7 +98,7 @@ describe MDL::CiteDetails do
     end
 
     it 'transforms the geonames field' do
-      expect(subject.to_hash[:fields][18]).to eq({:label=>"GeoNames URI", :field_values => [{:text=>"<a href=\"http://example.com\">http://example.com</a>", :url=>"/catalog?f[geonam_ssi][]=http%3A%2F%2Fexample.com"}]})
+      expect(subject.to_hash[:fields][18]).to eq({:label=>"GeoNames URI", :field_values => [{:text=>"<a href=\"http://example.com\">http://example.com</a>"}]})
     end
 
     it 'transforms the language field' do


### PR DESCRIPTION
Use div for block display of field value elements, and remove faceting behavior of GeoNames URI. The GeoNames URI will now render as a link to geonames.org rather than a catalog search with the URI value as a facet.

Fixes #293 