### PR TITLE
Remove Turbolinks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,6 @@ gem 'execjs'
 # # Use jquery as the JavaScript library
 gem 'jquery-rails'
 # # Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
-gem 'turbolinks'
 # # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.0'
 gem 'net-smtp', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -700,9 +700,6 @@ GEM
       actionpack (>= 3.0.0)
     traces (0.7.0)
     trailblazer-option (0.1.2)
-    turbolinks (5.2.1)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
     twitter-typeahead-rails (0.11.1.pre.corejavascript)
       actionpack (>= 3.1)
       jquery-rails
@@ -817,7 +814,6 @@ DEPENDENCIES
   strscan (= 3.0.1)
   teaspoon-jasmine
   thread-local
-  turbolinks
   twitter-typeahead-rails (= 0.11.1.pre.corejavascript)
   uglifier (>= 1.3.0)
   vcr

--- a/app/assets/javascripts/advanced-search/facet_multiselect.js
+++ b/app/assets/javascripts/advanced-search/facet_multiselect.js
@@ -1,4 +1,4 @@
-$(document).on('turbolinks:load', function () {
+$(document).ready(function () {
   $(".advanced-search-facet-select").chosen({
     placeholder_text_multiple: "Select...",
     single_backstroke_delete: false,

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,7 +15,6 @@
 
 //= require jquery3
 //= require rails-ujs
-//= require turbolinks
 //= require popper
 //= require twitter/typeahead
 //= require bootstrap

--- a/app/assets/javascripts/home.js.erb
+++ b/app/assets/javascripts/home.js.erb
@@ -1,4 +1,4 @@
-$( document ).on('turbolinks:load', function() {
+$( document ).ready(function() {
 
   // Work-around - safari hangs for a bit before setting focus when
   // autocomplete has been enabled
@@ -23,9 +23,7 @@ $( document ).on('turbolinks:load', function() {
 
   $('.home-page .more_facets_link').removeClass('more_facets_link');
 
-  $(document).ready(function() {
-    $('.search_q').focus();
-  });
+  $('.search_q').focus();
 
   reinitModal();
 });

--- a/app/helpers/mdl_blacklight_helper.rb
+++ b/app/helpers/mdl_blacklight_helper.rb
@@ -71,7 +71,6 @@ module MDLBlacklightHelper
         id: document.id
       ),
       document_link_params(document, opts)
-        .merge(data: { turbolinks: false })
     )
   end
 

--- a/app/views/catalog/_map_view.html.erb
+++ b/app/views/catalog/_map_view.html.erb
@@ -1,5 +1,5 @@
 <% if coordinates  %>
-  <div class="col-sm-12" data-turbolinks="false">
+  <div class="col-sm-12">
     <div id="<%= map_id %>"></div>
     <script>
       <% if with_popup %>

--- a/app/views/catalog/_show_more_like_this.html.erb
+++ b/app/views/catalog/_show_more_like_this.html.erb
@@ -1,4 +1,4 @@
-<li class="more_like_this_document" data-turbolinks="false">
+<li class="more_like_this_document">
   <span class="mlt_title">
     <%=
       link_to(

--- a/app/views/spotlight/pages/_order_pages.html.erb
+++ b/app/views/spotlight/pages/_order_pages.html.erb
@@ -21,7 +21,7 @@
 <%- end -%>
 <div>
   <%= form_for @page, url: spotlight.polymorphic_path([@exhibit, page_collection_name.to_sym]), html: {class: "expanded-add-button"} do |f|%>
-    <a href='#add-new' class="btn btn-primary" data-turbolinks="false" data-expanded-add-button="true" data-field-target="[data-title-field]">
+    <a href='#add-new' class="btn btn-primary" data-expanded-add-button="true" data-field-target="[data-title-field]">
       <%= t(:'.new_page') %> <span class="glyphicon glyphicon-chevron-right"></span>
       <span data-title-field="true" class="input-field">
         <%= f.text_field(:title) %>


### PR DESCRIPTION
We've had enough navigation + JS load issues caused by Turbolinks that removing it entirely is a justifiable path forward. The optimization tradeoffs are no longer favorable in the presence of these issues.

Fixes Minitex/mdl_deploy#12 