### PR TITLE
Explicitly use routes from main app

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -88,8 +88,8 @@ class CatalogController < ApplicationController
     @citation_config = MDL::CitationConfig.new(
       document: @document,
       base_url: request.base_url,
-      download_request_url: archive_download_requests_path,
-      download_ready_url: ready_archive_download_request_path(@document['id'])
+      download_request_url: main_app.archive_download_requests_path,
+      download_ready_url: main_app.ready_archive_download_request_path(@document['id'])
     )
 
     respond_to do |format|


### PR DESCRIPTION
When in the context of a Spotlight exhibit, routes referenced in controllers of the host app must specifically reference the routes it defines or else a UrlGenerationError will be raised. We can do that by calling the routes on `main_app` explicitly, rather than using an implicit `self` receiver.