### PR TITLE
Add modal for transcript caveat

### DIFF
--- a/app/assets/stylesheets/mdl.scss
+++ b/app/assets/stylesheets/mdl.scss
@@ -233,7 +233,6 @@ h3.index_title {
 		display: block;
 		margin: .75rem;
 		padding: 0;
-		width: 100%;
 
 		.ajax-modal-close {
 			display: none;
@@ -253,10 +252,13 @@ h3.index_title {
 	.modal-footer {
 		margin: .75rem;
 		padding: 0;
-		width: 100%;
 
 		.facet_pagination {
 			padding: .75rem 0;
+		}
+
+		.modal-dismiss {
+			margin-top: .75rem;
 		}
 	}
 
@@ -271,6 +273,11 @@ h3.index_title {
 	.sort-options {
 		float: right;
 	}
+}
+
+
+.ocr-transcript-info {
+	padding: 0.75rem;
 }
 
 .search-btn {

--- a/app/javascript/react-citation/cite-transcript.js
+++ b/app/javascript/react-citation/cite-transcript.js
@@ -1,7 +1,72 @@
 import React from 'react'
 import PropTypes from 'prop-types';
 
-const Transcript = props => (<div className="transcript">{props.transcript}</div>)
+const Modal = () => {
+  return (
+    <div className="modal" id="transcriptModal" tabIndex="-1" role="dialog">
+      <div className="modal-dialog" role="document">
+        <div className="modal-content">
+          <div className="modal-header transcript-ocr">
+            <button type="button" className="close" data-dismiss="modal" aria-label="Close">
+              <span aria-hidden="true">&times;</span>
+            </button>
+            <h5 className="modal-title">Optical Character Recognition Text</h5>
+          </div>
+          <div className="modal-body">
+            <p>Why are there errors in the transcript?</p>
+            <p>
+              Optical Character Recognition, or OCR*, is a process by which software
+              reads a page image and translates it into a text file by recognizing
+              the shapes of the letters. We perform OCR on text-based resources,
+              like books and letters, to enable full-text searching.
+            </p>
+            <p>
+              However, OCR is seldom completely accurate. The level of accuracy
+              depends on the print quality of the original materials, their condition
+              at the time of digitization, the level of detail captured by scanners,
+              and the quality of the OCR software. Scans of pages with poor quality
+              paper, small or faded print, mixed fonts, multiple column layouts, or
+              damage may result in low OCR accuracy.
+            </p>
+
+            <p>
+              The searchable text in this transcript has been automatically generated
+              using OCR software. It has not been manually reviewed or corrected.
+            </p>
+
+            <p>
+              *Source:
+              <a href="https://www.ninch.org/guide.pdf" target="_blank" rel="noopener">
+                The NINCH Guide to Good Practice in the Digital Representation and Management of Cultural Heritage Materials.
+              </a>
+            </p>
+          </div>
+          <div className="modal-footer transcript-ocr">
+            <button
+              type="button"
+              className="btn btn-secondary modal-dismiss"
+              data-dismiss="modal"
+            >Close</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const Transcript = (props) => {
+  return (
+    <>
+      <div className="ocr-transcript-info">
+        <a data-toggle="modal" data-target="#transcriptModal" href="#">
+          Why are there errors in the transcript?
+        </a>
+      </div>
+      <div className="transcript">{props.transcript}</div>
+      <Modal />
+    </>
+  );
+};
 
 const propTypes = {
   transcript: PropTypes.string.isRequired


### PR DESCRIPTION
This adds a modal to the transcript tab which explains the OCR process and why the transcript might not be completely accurate.

<img width="1140" alt="Screenshot 2023-07-22 at 4 10 57 PM" src="https://github.com/Minitex/mdl_search/assets/815279/6836ac8e-4345-42c0-9dcb-06eb9958c0eb">
<img width="1104" alt="Screenshot 2023-07-22 at 4 11 22 PM" src="https://github.com/Minitex/mdl_search/assets/815279/78fdbdd5-7955-461b-92d0-0f1eb278bd20">
