### PR TITLE
Revive the search constraints panel

### DIFF
--- a/app/assets/stylesheets/mdl.scss
+++ b/app/assets/stylesheets/mdl.scss
@@ -932,7 +932,13 @@ form.range_limit .btn-secondary {
 .constraints-container {
 	background-color: $lightest-gray;
 	border-color: $light-gray;
-	margin: 10px 0 20px;
+	margin: 10px 15px;
+	padding: .5rem;
+	align-items: center;
+}
+
+.constraints-start-over {
+	margin-left: auto;
 }
 
 #sortAndPerPage {

--- a/app/overrides/blacklight_advanced_search/render_constraints_override_override.rb
+++ b/app/overrides/blacklight_advanced_search/render_constraints_override_override.rb
@@ -1,0 +1,30 @@
+module BlacklightAdvancedSearch
+  module RenderConstraintsOverrideOverride
+    ##
+    # Render the facet constraints
+    # This is the original Blacklight implementation, which is overridden by
+    # BlacklightAdvancedSearch. The override doesn't work for our purposes,
+    # because it ends up duplicating the facets in the constraints panel
+    # of the search results page.
+    #
+    # @deprecated
+    # @param [Blacklight::SearchState,Hash] params_or_search_state query parameters
+    # @return [String]
+    def render_constraints_filters(params_or_search_state = search_state)
+      Deprecation.warn(Blacklight::RenderConstraintsHelperBehavior, 'render_constraints_filters is deprecated')
+      search_state = convert_to_search_state(params_or_search_state)
+
+      return "".html_safe unless search_state.filters.any?
+
+      Deprecation.silence(Blacklight::RenderConstraintsHelperBehavior) do
+        safe_join(search_state.filters.map do |field|
+          render_filter_element(field.key, field.values, search_state)
+        end, "\n")
+      end
+    end
+  end
+end
+
+BlacklightAdvancedSearch::RenderConstraintsOverride.prepend(
+  BlacklightAdvancedSearch::RenderConstraintsOverrideOverride
+)

--- a/app/views/catalog/_constraints.html.erb
+++ b/app/views/catalog/_constraints.html.erb
@@ -1,9 +1,9 @@
 <% if rendered_constraints = render_constraints(params).presence %>
-  <div id="appliedParams" class="clearfix constraints-container">
-    <div class="pull-right">
-      <%=link_to t('blacklight.search.start_over'), start_over_path, :class => "catalog_startOverLink btn btn-sm btn-text", :id=>"startOverLink" %>
-    </div>
+  <div id="appliedParams" class="constraints-container">
     <span class="constraints-label"><%= t('blacklight.search.filters.title') %></span>
     <%= rendered_constraints %>
+    <div class="constraints-start-over">
+      <%= link_to t('blacklight.search.start_over'), start_over_path, class: "catalog_startOverLink btn btn-sm btn-text", id: "startOverLink" %>
+    </div>
   </div>
 <% end %>

--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -9,6 +9,12 @@
   <%= json_api_link_tag %>
 <% end %>
 
+<% content_for(:container_header) do -%>
+  <h2 class="sr-only visually-hidden top-content-title"><%= t('blacklight.search.header') %></h1>
+
+  <%= render 'constraints' %>
+<% end %>
+
 <%= render 'search_header' %>
 
 <div class="top-pagination"><%= render partial: 'results_pagination', locals: {show_json_link: false}%></div>

--- a/app/views/layouts/blacklight.html.erb
+++ b/app/views/layouts/blacklight.html.erb
@@ -46,7 +46,7 @@
   <%= render partial: 'shared/search_block' unless current_page?('/advanced') %>
 
   <div id="main-container" class="<%= container_classes %>">
-
+    <%= content_for(:container_header) %>
     <%= content_tag :h1, application_name, class: 'sr-only application-heading' %>
 
     <%= render partial: 'shared/flash_msg', layout: 'shared/flash_messages' %>

--- a/spec/features/advanced_search_spec.rb
+++ b/spec/features/advanced_search_spec.rb
@@ -26,9 +26,9 @@ describe 'advanced search' do
       count: 3
     )
 
-    # filters = page.all('.appliedFilter', count: 1)
-    # filters.first.find('.filterName', text: 'Title')
-    # filters.first.find('.filterValue', text: 'Streetcar')
+    filters = page.all('.applied-filter', count: 1)
+    filters.first.find('.filter-name', text: 'Title')
+    filters.first.find('.filter-value', text: 'Streetcar')
 
     type_facet,
     format_facet,


### PR DESCRIPTION
It looks like we lost this in the Blacklight upgrade, but this PR brings back the search constraints panel. I had to override a Blacklight helper method that BlacklightAdvancedSearch was also overriding because the way BlacklightAdvancedSearch had it, the facets were being duplicated.

<img width="1123" alt="Screenshot 2023-07-23 at 9 15 33 PM" src="https://github.com/Minitex/mdl_search/assets/815279/532b56f3-ff97-47b9-b9fa-4d49224ae256">

