### PR TITLE
Allow for dynamic configuration of UniversalViewer

### DIFF
--- a/app/controllers/uvconfig_controller.rb
+++ b/app/controllers/uvconfig_controller.rb
@@ -1,0 +1,18 @@
+#
+# This controller gives us a way to dynamically vary the configuration
+# of UniversalViewer based on any attributes of the Solr document being
+# viewed. Due to the low number of dynamic values, we're currently
+# just rendering an ERB template; but if the number grows, we likely
+# should consider building an object structure that we can serialize to
+# JSON instead.
+#
+class UvconfigController < ApplicationController
+  include Blacklight::Catalog
+
+  def show
+    _response, document = search_service.fetch(params[:id])
+    bd = MDL::BorealisDocument.new(document:)
+
+    @left_panel_open = !bd.assets.first.playlist?
+  end
+end

--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -78,7 +78,7 @@
       createUV('#uv', {
         iiifResourceUri: '<%= manifest_url %>',
         root: '../../../uv/',
-        configUri: '/uv/config.json',
+        configUri: '<%= uvconfig_path(params[:id]) %>',
         collectionIndex: (collectionIndex !== undefined) ? Number(collectionIndex) : undefined,
         manifestIndex: Number(urlDataProvider.get('m', 0)),
         sequenceIndex: Number(urlDataProvider.get('s', 0)),

--- a/app/views/uvconfig/show.json.erb
+++ b/app/views/uvconfig/show.json.erb
@@ -13,6 +13,12 @@
     "zoomToBoundsEnabled": false
   },
   "modules": {
+    "contentLeftPanel": {
+      "options": {
+        "panelOpen": <%= @left_panel_open %>,
+        "defaultToTreeEnabled": true
+      }
+    },
     "headerPanel": {
       "options": {
         "localeToggleEnabled": false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,6 +79,8 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :uvconfig, only: [:show]
+
   get 'contentdm-images' => 'contentdm_images#show'
   get 'contentdm-images/info' => 'contentdm_images#info'
   get 'thumbnails/:id/(:type)' => 'thumbnails#show', as: 'thumbnail'

--- a/prep_uv.sh
+++ b/prep_uv.sh
@@ -2,4 +2,3 @@
 
 cp -R node_modules/universalviewer/dist public/uv
 rm public/uv/*.zip
-cp config/uv-config.json.example public/uv/config.json

--- a/spec/requests/uvconfig_spec.rb
+++ b/spec/requests/uvconfig_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+describe 'UV config requests' do
+  let(:headers) do
+    { 'Accept' => 'application/json' }
+  end
+
+  context 'with an AV playlist' do
+    before { solr_fixtures('sll:22470') }
+
+    it 'returns config for left panel closed' do
+      get('/uvconfig/sll:22470', headers:)
+      expect(response).to have_http_status(:ok)
+      parsed_body = JSON.parse(response.body)
+      panel_open = parsed_body.dig(
+        'modules',
+        'contentLeftPanel',
+        'options',
+        'panelOpen'
+      )
+      expect(panel_open).to eq(false)
+    end
+  end
+
+  context 'with a non-playlist' do
+    before { solr_fixtures('msn:2277') }
+
+    it 'returns config for left panel open' do
+      get('/uvconfig/msn:2277', headers:)
+      expect(response).to have_http_status(:ok)
+      parsed_body = JSON.parse(response.body)
+      panel_open = parsed_body.dig(
+        'modules',
+        'contentLeftPanel',
+        'options',
+        'panelOpen'
+      )
+      expect(panel_open).to eq(true)
+    end
+  end
+end


### PR DESCRIPTION
This adds a controller for rendering the UV config that can, in
principle, vary any portion of the configuration based on attirbutes of
the document being rendered. For now, it's limited to collapsing the
left panel by default for AV playlists, but it's possible to extend this
approach for other document categories as well.