### PR TITLE
Fix capitalization of Contributing Org in item metadata

### DIFF
--- a/lib/mdl/cite_details.rb
+++ b/lib/mdl/cite_details.rb
@@ -32,7 +32,7 @@ module MDL
       # @return [Array<MDL::CiteDetails::FieldConfig>]
       def field_configs
         [
-          FieldConfig.new(key: 'contributing_organization_ssi', label: 'Contributing Organization', facet: true),
+          FieldConfig.new(key: 'contributing_organization_tesi', label: 'Contributing Organization', facet: true),
           FieldConfig.new(key: 'title_ssi', label: 'Title'),
           FieldConfig.new(key: 'creator_ssim', label: 'Creator', delimiter: ', ', facet: true),
           FieldConfig.new(key: 'contributor_ssim', label: 'Contributor', delimiter: ', ', facet: true),

--- a/spec/fixtures/solr_doc.json
+++ b/spec/fixtures/solr_doc.json
@@ -25,6 +25,7 @@
   "parent_collection_name_ssi": "collection here",
   "language_ssi":"English",
   "contributing_organization_ssi":"Minnesota Geological Survey",
+  "contributing_organization_tesi":"Minnesota Geological Survey",
   "contact_information_ssi":"Minnesota Geological Survey, 2642 University Avenue, St. Paul, MN 55114",
   "rights_ssi":"Public domain.  We request that if the images are used credit be given to the Minnesota Geological Survey, University of Minnesota.",
   "local_identifier_ssi":"a5 Pl1",

--- a/spec/lib/mdl/cite_details_spec.rb
+++ b/spec/lib/mdl/cite_details_spec.rb
@@ -25,7 +25,7 @@ describe MDL::CiteDetails do
   end
   describe "when transforming records" do
     it 'transforms the contributing organization field' do
-      expect(subject.to_hash[:fields][0]).to eq({:label=>"Contributing Organization", :field_values=>[{:text=>"Minnesota Geological Survey", :url=>"/catalog?f[contributing_organization_ssi][]=Minnesota+Geological+Survey"}]})
+      expect(subject.to_hash[:fields][0]).to eq({:label=>"Contributing Organization", :field_values=>[{:text=>"Minnesota Geological Survey", :url=>"/catalog?f[contributing_organization_tesi][]=Minnesota+Geological+Survey"}]})
     end
 
 


### PR DESCRIPTION
By switching to a different Solr field, one that holds the same raw data but applies different indexing analyzers, we can fix the capitalization issue of the Contributing Organization name in the item metadata. The _tesi field is not transformed using the Titleize filter so its content will remain in tact.