### PR TITLE
Revise deep linking strategy for compound items

### DIFF
--- a/app/helpers/mdl_blacklight_helper.rb
+++ b/app/helpers/mdl_blacklight_helper.rb
@@ -69,7 +69,7 @@ module MDLBlacklightHelper
         controller: 'catalog',
         action: 'show',
         id: document.id,
-        anchor: document_link_anchor(document)
+        uvcv: desired_canvas_index(document)
       ),
       document_link_params(document, opts)
     )
@@ -82,10 +82,8 @@ module MDLBlacklightHelper
   #
   # @param document [SolrDocument]
   # @return [String, nil]
-  def document_link_anchor(document)
-    cmpd_doc_page_idx = Array(document['identifier_ssim']).index(params[:q])
-    return unless cmpd_doc_page_idx
-    "?cv=#{cmpd_doc_page_idx}"
+  def desired_canvas_index(document)
+    Array(document['identifier_ssim']).index(params[:q])
   end
 
   def document_metadata(document)

--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -48,6 +48,21 @@
 
 <% content_for(:blocking_javascript) do %>
   <script type="text/javascript">
+    function getQueryParams() {
+      const url = window.location.href;
+      const params = new URLSearchParams((new URL(url)).search);
+      const obj = {};
+
+      for (const [key, value] of params.entries()) {
+          obj[key] = value;
+      }
+
+      return obj;
+    }
+    const queryParams = getQueryParams();
+    if (queryParams.uvcv && queryParams.uvcv.length) {
+      window.location.hash = `?${queryParams.uvcv}`;
+    }
     window.addEventListener('uvLoaded', function (e) {
       const urlDataProvider = new UV.URLDataProvider();
       const collectionIndex = urlDataProvider.get('c');
@@ -55,7 +70,7 @@
       // If we were given a legacy anchor, such as #/image/4, parse
       // out the 4 and use it as the canvasIndex in the UV config.
       const legacyAnchorMatch = /\/image\/(\d+)$/.exec(window.location.hash) || [0];
-      let canvasIndexFallback = legacyAnchorMatch.pop();
+      let canvasIndexFallback = queryParams.uvcv || legacyAnchorMatch.pop();
       if (legacyAnchorMatch.length) {
         window.location.hash = '';
       }


### PR DESCRIPTION
We recently removed Turbolinks, and when we did, it ended up breaking our implementation for deep linking. This one should be a little more robust, since it works with query params rather than anchors.