### PR TITLE
Add `identifier` field to OAI record response

### DIFF
--- a/app/assets/stylesheets/blacklight_oai_provider/oai2.xsl
+++ b/app/assets/stylesheets/blacklight_oai_provider/oai2.xsl
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/ | @* | node()">
+  <xsl:copy>
+    <xsl:apply-templates select="@* | node()" />
+  </xsl:copy>
+  </xsl:template>
+</xsl:stylesheet>

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 class SolrDocument
-
   include Blacklight::Solr::Document
   include Blacklight::Gallery::OpenseadragonSolrDocument
 
@@ -9,6 +8,8 @@ class SolrDocument
   include Spotlight::SolrDocument::AtomicUpdates
   include BlacklightOaiProvider::SolrDocument
 
+  MDL_ITEM_URL_FIELD = 'mdl_item_url'.freeze
+  private_constant :MDL_ITEM_URL_FIELD
 
   # self.unique_key = 'id'
 
@@ -40,7 +41,8 @@ class SolrDocument
     source: 'publishing_agency_ssi',
     relation: 'topic_ssim',
     publisher: 'contributing_organization_ssi',
-    rights: 'rights_ssi'
+    rights: 'rights_ssi',
+    identifier: MDL_ITEM_URL_FIELD
   )
 
   # @!attribute [r] contributing_organization
@@ -59,6 +61,19 @@ class SolrDocument
       return doc if doc.is_a?(SolrDocument)
       new(doc)
     end
+  end
+
+  ###
+  # Override the default implementation here to inject a link
+  # to the item into the wrapped source document. This allows
+  # us to return an identifier in the OAI record response without
+  # having to store it in Solr.
+  def initialize(source_doc = {}, response = nil)
+    item_url = "https://collection.mndigital.org/catalog/#{source_doc['id']}"
+    super(
+      source_doc.merge(MDL_ITEM_URL_FIELD => item_url),
+      response
+    )
   end
 
   def more_like_this

--- a/spec/features/search_by_mdl_identifier_spec.rb
+++ b/spec/features/search_by_mdl_identifier_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'searching by MDL identifier', :skip_ci do
+describe 'searching by MDL identifier' do
   context 'in a compound document' do
     before { solr_fixtures('spl:3207') }
 

--- a/spec/requests/oai_get_record_spec.rb
+++ b/spec/requests/oai_get_record_spec.rb
@@ -23,5 +23,6 @@ describe 'OAI GetRecord verb' do
     expect(metadata.xpath('//oai_dc:dc/dc:relation', ns).text).to eq 'Architecture'
     expect(metadata.xpath('//oai_dc:dc/dc:publisher', ns).text).to eq 'Otter Tail County Historical Society'
     expect(metadata.xpath('//oai_dc:dc/dc:rights', ns).text).to eq 'Copyright © 2005 Otter Tail County Historical Society. Contact contributing institution for reproduction.'
+    expect(metadata.xpath('//oai_dc:dc/dc:identifier', ns).text).to eq 'https://collection.mndigital.org/catalog/otter:297'
   end
 end


### PR DESCRIPTION
This provides a new field, `identifier`, on the OAI GetRecord response.
Since the links aren't actually persisted in Solr, we need to generate
it in the `SolrDocument` constructor and merge it into the source
document that class wraps. It seems better to do this than to write a
new field to the Solr index for every document.