### PR TITLE
Don't report Blacklight RecordNotFound to Sentry

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,3 +1,6 @@
 Raven.configure do |config|
-  config.excluded_exceptions += [MDL::EtlAuditing::JobNotYetCreatedError]
+  config.excluded_exceptions += [
+    MDL::EtlAuditing::JobNotYetCreatedError,
+    Blacklight::Exceptions::RecordNotFound
+  ]
 end


### PR DESCRIPTION
Sending a RecordNotFound exception to Sentry is more noise than value, so we should stop doing it.

Addresses https://minitex.sentry.io/issues/4219334420