### PR TITLE
Upgrade Sentry client to sentry-ruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -98,5 +98,7 @@ gem 'blacklight-oembed', '~> 1.1'
 gem 'autoprefixer-rails', '~> 10.4.7' # Constraint to accommodate Node 8 on QA/Prod
 gem 'kaltura-client'
 
-gem 'sentry-raven'
+gem 'sentry-ruby'
+gem 'sentry-rails'
+gem 'sentry-sidekiq'
 gem 'strscan', '3.0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -612,8 +612,14 @@ GEM
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
     semantic_range (3.0.0)
-    sentry-raven (3.1.2)
-      faraday (>= 1.0)
+    sentry-rails (5.12.0)
+      railties (>= 5.0)
+      sentry-ruby (~> 5.12.0)
+    sentry-ruby (5.12.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+    sentry-sidekiq (5.12.0)
+      sentry-ruby (~> 5.12.0)
+      sidekiq (>= 3.0)
     shoulda-matchers (5.3.0)
       activesupport (>= 5.2.0)
     sidekiq (6.5.10)
@@ -773,7 +779,9 @@ DEPENDENCIES
   rubyzip
   sass-rails (~> 5.0)
   selenium-webdriver
-  sentry-raven
+  sentry-rails
+  sentry-ruby
+  sentry-sidekiq
   shoulda-matchers
   sidekiq (~> 6.5)
   sidekiq-failures (~> 1.0)

--- a/app/services/mdl/etl.rb
+++ b/app/services/mdl/etl.rb
@@ -22,7 +22,7 @@ module MDL
       msg_which = set_specs.size > 1 ? "#{set_specs.size} collections" : set_specs.first
       msg_from = from ? "from #{from}" : ''
       message = "ETL Started for #{msg_which} #{msg_from}".rstrip
-      Raven.capture_message(message)
+      Sentry.capture_message(message)
       CDMBL::ETLBySetSpecs.new(
         set_specs: set_specs,
         etl_config: config.tap { |c| c.merge!(from: from) if from },

--- a/app/services/mdl/etl_auditing.rb
+++ b/app/services/mdl/etl_auditing.rb
@@ -55,7 +55,7 @@ module MDL
     end
 
     def notify_complete
-      Raven.capture_message('ETL Finished')
+      Sentry.capture_message('ETL Finished')
     end
 
     def indexing_finished?(indexing_run)

--- a/config/initializers/cdmbl.rb
+++ b/config/initializers/cdmbl.rb
@@ -37,7 +37,7 @@ module CDMBL
   class BatchDeleteJobCompletedCallback
     def self.call!
       Rails.logger.info "CDMBL: Batch delete job complete"
-      Raven.capture_event('Batch delete job complete')
+      Sentry.capture_message('Batch delete job complete')
     end
   end
 

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,3 +1,6 @@
-Raven.configure do |config|
-  config.excluded_exceptions += [MDL::EtlAuditing::JobNotYetCreatedError]
+Sentry.init do |config|
+  config.excluded_exceptions += [
+    'MDL::EtlAuditing::JobNotYetCreatedError',
+    'Blacklight::Exceptions::RecordNotFound'
+  ]
 end

--- a/lib/mdl/kaltura_playlist_data_formatter.rb
+++ b/lib/mdl/kaltura_playlist_data_formatter.rb
@@ -24,9 +24,9 @@ module MDL
         KalturaMediaEntryService.get(playlist_id)
       rescue Kaltura::KalturaAPIError => e
         Rails.logger.error(e.message)
-        Raven.capture_message(
+        Sentry.capture_message(
           'Kaltura playlist not found',
-          playlist_id: playlist_id
+          extra: { playlist_id: }
         )
         nil
       end

--- a/lib/tasks/prune.rake
+++ b/lib/tasks/prune.rake
@@ -10,7 +10,7 @@ namespace :prune do
   end
 
   def do_prune(solr_query: nil)
-    Raven.send_event(Raven::Event.new(message: 'Batch delete job started'))
+    Sentry.capture_message('Batch delete job started')
     CDMBL::BatchDeleterWorker.perform_async(
       0,
       50,


### PR DESCRIPTION
We've been using sentry-raven, which is now in maintenance mode. Sentry recommends using sentry-ruby, which provides async integration with the server, performance monitoring, and other niceties.