### PR TITLE
Commit Solr index prior to notifying Sentry ETL is complete

### DIFF
--- a/app/services/mdl/etl_auditing.rb
+++ b/app/services/mdl/etl_auditing.rb
@@ -29,8 +29,8 @@ module MDL
 
       job.update(completed_at: Time.current)
       if indexing_finished?(indexing_run)
-        notify_complete
         SolrClient.new.commit
+        notify_complete
       end
     end
 

--- a/lib/tasks/ingester.rake
+++ b/lib/tasks/ingester.rake
@@ -31,7 +31,6 @@ namespace :mdl_ingester do
 
   desc 'Launch a background job to index a single record.'
   task :record, [:id] => :environment do |t, args|
-    require Rails.root.join('lib/mdl/etl_worker')
     IndexingRun.create!
     MDL::TransformWorker.perform_async(
       [args[:id].split(':')],


### PR DESCRIPTION
In QA, we've occasionally seen Sentry notifications that ETL is complete, but we won't see the expected changes reflected in Solr search results. A Solr commit fixes it, but it should be happening already baseed on the code in EtlAuditing. This change just swaps the order of notification and commit, so that we only notify once the commit has happened.