### PR TITLE
Github Actions - Save and upload artifact when feature specs fail

### DIFF
--- a/.github/workflows/validate-pull-request.yaml
+++ b/.github/workflows/validate-pull-request.yaml
@@ -51,3 +51,9 @@ jobs:
         run: ./prep_uv.sh
       - name: Run Tests
         run: bundle exec rspec --tag ~skip_ci
+      - name: Upload Capybara Saved Pages
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: capybara
+          path: tmp/capybara

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -93,5 +93,11 @@ RSpec.configure do |config|
       spec.run
       Capybara.use_default_driver
     end
+
+    config.after(:each, type: :feature) do |e|
+      next unless e.exception
+      save_page
+      save_screenshot
+    end
   end
 end


### PR DESCRIPTION
When feature specs fail in CI, it will be helpful to have an artifact containing the screenshot an HTML of the pages that didn't meet expectations.