### PR TITLE
Use more specific selector in feature spec

### DIFF
--- a/spec/features/search_by_mdl_identifier_spec.rb
+++ b/spec/features/search_by_mdl_identifier_spec.rb
@@ -10,10 +10,7 @@ describe 'searching by MDL identifier' do
       click_on 'Search'
       result_link = find_link('A Statewide Movement for the Collection and Preservation of Minnesota\'s War Records')
       result_link.click
-
-      within('.searchResults') do
-        expect(page).to have_content('image 9 of 24')
-      end
+      expect(page).to have_selector('.searchResults', text: 'image 9 of 24')
     end
   end
 end


### PR DESCRIPTION
We were seeing this test fail in CI somewhat consistently, but I struggled to reproduce it locally. I finally discovered that I had been working with an out of date UV config.json file, which hard coded the left panel to be closed. As a result, I wasn't seeing the ambiguous selector error that was present in CI. After clearing that stale file and regenerating it with `./prep_uv.sh`, I was able to see the error and fix the problem. The new upload artifact feature in CI helped uncover the issue because both the screenshot and the HTML showed the left panel open with multiple `.searchResults` selectors.