### PR TITLE
Resolve routing issue when viewing exhibits

### DIFF
--- a/app/components/range_facet_component.rb
+++ b/app/components/range_facet_component.rb
@@ -4,4 +4,18 @@ class RangeFacetComponent < BlacklightRangeLimit::RangeFacetComponent
   # a modal containing the range limit chart
   def more_link(*)
   end
+
+  ###
+  # Override to ensure the route is targeting CatalogController. Without
+  # this, route generation will fail when in the context of a Spotlight Exhibit.
+  def range_limit_url(options = {})
+    url_config = @facet_field.search_state.to_h.merge(
+      range_field: @facet_field.key,
+      action: 'range_limit',
+      controller: '/catalog',
+      **options
+    )
+
+    helpers.main_app.url_for(url_config)
+  end
 end


### PR DESCRIPTION
This overrides a method on BlacklightRangeLimit's RangeFacetComponent to ensure that the route is generated against CatalogController. The overridden method doesn't seem to be considering the possiblility that the current controller context could be a spotlight one.