### PR TITLE
Use a four column layout for exhibits at large breakpoint

### DIFF
--- a/app/views/spotlight/exhibits/_exhibits.html.erb
+++ b/app/views/spotlight/exhibits/_exhibits.html.erb
@@ -1,0 +1,3 @@
+<div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4">
+  <%= render collection: exhibits, partial: 'exhibit_card', as: 'exhibit' %>
+</div>

--- a/app/views/spotlight/exhibits/index.html.erb
+++ b/app/views/spotlight/exhibits/index.html.erb
@@ -1,4 +1,4 @@
-<div class="col-md-9">
+<div class="col">
   <% if current_user %>
     <ul class="nav nav-tabs" role="tablist">
       <li role="presentation" class="active"><a href="#published" aria-controls="published" role="tab" data-toggle="tab"><%= t('.published') %></a></li>


### PR DESCRIPTION
Update the exhibits layout to switch to four columns at the large breakdown.

<img width="1108" alt="Screenshot 2023-12-03 at 8 43 21 PM" src="https://github.com/Minitex/mdl_search/assets/815279/ce4143e8-75cb-4fb8-8c78-e55143188838">
