### PR TITLE
Provide means to test various boost values for transcription

### DIFF
--- a/app/components/search_bar_component.html.erb
+++ b/app/components/search_bar_component.html.erb
@@ -26,6 +26,18 @@
     %>
   </div>
 
+  <span class="input-group">
+    <label for="transcription_boost" class="sr-only">Transcription Boost</label>
+    <input
+      type="number"
+      min="1"
+      class="form-control"
+      name="transcription_boost"
+      placeholder="Transcription Boost"
+      value="<%= params[:transcription_boost] %>"
+    />
+  </span>
+
   <span class="input-group input-group-btn">
     <label for="search" class="sr-only"><%= t('blacklight.search.form.submit') %></label>
     <button type="submit" class="btn btn-primary search-btn" id="search">

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -388,7 +388,12 @@ class CatalogController < ApplicationController
     # solr request handler? The one set in config[:default_solr_parameters][:qt],
     # since we aren't specifying it otherwise.
 
-    config.add_search_field 'all_fields', label: 'All Fields'
+    config.add_search_field(
+      'all_fields',
+      label: 'All Fields',
+      query_builder: GenerateLocalParams,
+      advanced_parse: false
+    )
 
 
     # Now we see how to over-ride Solr request handler defaults, in this

--- a/app/controllers/generate_local_params.rb
+++ b/app/controllers/generate_local_params.rb
@@ -1,0 +1,100 @@
+module GenerateLocalParams
+  extend self
+
+  QF = %w(
+    id^180000
+    title_unstem_search^160000
+    title_tei^140000
+    contributor_unstem_search^55000
+    contributor_teim^50000
+    creator_teim^50000
+    creator_unstem_search^55000
+    transcription_tesi^25000
+    description_tei
+    publishing_agency_tei
+    publishing_agency_unstem_search
+    topic_teim^90000
+    topic_unstem_search^140000
+    formal_subject_teim^100000
+    formal_subject_unstem_search^150000
+    subject_teim^100000
+    subject_unstem_search^150000
+    city_unstem_search
+    district_unstem_search
+    county_unstem_search
+    state_unstem_search
+    country_unstem_search
+    language_unstem_search
+    contributing_organization_tei
+    contributing_unstem_search
+    translation_tesi
+    geographic_feature_tei
+    geographic_feature_unstem_search
+    image_ids_ssim
+    kaltura_audio_ssi
+    kaltura_audio_playlist_ssi
+    kaltura_video_ssi
+    local_identifier_ssi
+    identifier_ssi
+    identifier_ssim
+    type_ssi
+    type_tesi
+    dat_tesi
+  ).join(' ')
+  private_constant :QF
+
+  PF = %w(
+    id^180000
+    title_unstem_search^150000
+    title_tei^100000
+    contributor_unstem_search^55000
+    contributor_teim^50000
+    creator_teim^50000
+    creator_unstem_search^55000
+    description_tei
+    publishing_agency_tei
+    publishing_agency_unstem_search
+    topic_teim
+    topic_unstem_search
+    formal_subject_teim^100000
+    formal_subject_unstem_search^150000
+    subject_teim^100000
+    subject_unstem_search^150000
+    city_unstem_search
+    district_unstem_search
+    county_unstem_search
+    state_unstem_search
+    country_unstem_search
+    language_unstem_search
+    contributing_organization_tei
+    contributing_unstem_search
+    transcription_tei
+    geographic_feature_tei
+    geographic_feature_unstem_search
+    image_ids_ssim
+    type_ssi
+    type_tesi
+    dat_tesi
+  ).join(' ')
+  private_constant :PF
+
+  def call(search_builder, search_field, solr_parameters)
+    res = local_params(search_builder.blacklight_params)
+    "#{res}#{search_builder.blacklight_params[:q]}"
+  end
+
+  private
+
+  def local_params(params)
+    boost = params[:transcription_boost].to_i || 0
+    "{!dismax qf='#{local_qf(boost)}' pf='#{local_pf(boost)}'}"
+  end
+
+  def local_qf(boost)
+    boost.positive? ? "transcription_tesim^#{boost} #{QF}" : QF
+  end
+
+  def local_pf(boost)
+    boost.positive? ? "transcription_tesim^#{boost} #{PF}" : PF
+  end
+end


### PR DESCRIPTION
This provides a quick way to play with and calibarate the boost value for the transcription field when we incorporate it into the main search.

It is not intended to be a long-term solution.