### PR TITLE
Provide 'jump to page' input alongside pagination

### DIFF
--- a/app/assets/stylesheets/mdl.scss
+++ b/app/assets/stylesheets/mdl.scss
@@ -282,7 +282,7 @@ h3.index_title {
 
 .search-btn {
 	border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
+	border-bottom-left-radius: 0;
 }
 
 .blacklight-exhibits-index aside .nav-pills .btn-nav, .blacklight-sites-edit aside .nav-pills .btn-nav, .blacklight-sites-edit_exhibits aside .nav-pills .btn-nav, .blacklight-exhibits-new aside .nav-pills .btn-nav, .blacklight-home_pages-edit aside .nav-pills .btn-nav, .blacklight-exhibits-edit aside .nav-pills .btn-nav, .blacklight-appearances-edit aside .nav-pills .btn-nav, .blacklight-roles-index aside .nav-pills .btn-nav, .blacklight-metadata_configurations-edit aside .nav-pills .btn-nav, .blacklight-search_configurations-edit aside .nav-pills .btn-nav, .blacklight-catalog-admin aside .nav-pills .btn-nav, .blacklight-tags-index aside .nav-pills .btn-nav, .blacklight-searches-index aside .nav-pills .btn-nav, .blacklight-feature_pages-index aside .nav-pills .btn-nav, .blacklight-about_pages-index aside .nav-pills .btn-nav {
@@ -788,7 +788,6 @@ form.range_limit .btn-secondary {
 
 .icon-json {
   font-size: 3em;
-  margin-top: 15px;
 }
 
 .glossary {
@@ -1053,9 +1052,28 @@ h3.document-title-heading {
 	margin-bottom: 8px;
 }
 
+.number-to-text {
+	&::-webkit-inner-spin-button,
+	&::-webkit-outer-spin-button {
+		-webkit-appearance: none;
+		margin: 0;
+	}
+
+	appearance: textfield;
+	-moz-appearance: textfield;
+}
+
 .pagination {
 	margin: 15px 0 5px -7px;
-	float: left;
+	input.jump-to-page {
+		border: 1px solid $light-gray;
+		width: 60px;
+	}
+
+	.btn {
+		border-top-left-radius: 0;
+		border-bottom-left-radius: 0;
+	}
 }
 
 .pagination > li > a {

--- a/app/helpers/mdl_blacklight_helper.rb
+++ b/app/helpers/mdl_blacklight_helper.rb
@@ -10,7 +10,7 @@ module MDLBlacklightHelper
   end
 
   def json_result_link
-    link_to(raw('<div class="icon-json float-right"><span class="sr-only">Download JSON</span></div>'), current_search_json, {class: 'json-link'})
+    link_to(raw('<div class="icon-json"><span class="sr-only">Download JSON</span></div>'), current_search_json, {class: 'json-link'})
   end
 
   def json_page_link

--- a/app/helpers/params_helper.rb
+++ b/app/helpers/params_helper.rb
@@ -1,0 +1,45 @@
+module ParamsHelper
+  ###
+  # @param parameters [ActionController::Parameters]
+  # @return [String]
+  def params_as_hidden_fields(parameters)
+    hidden_fields_hash(parameters).reduce(''.html_safe) do |html, (param, value)|
+      if value.is_a?(Array)
+        value.each do |v|
+          html += hidden_field_tag(param, v)
+        end
+      else
+        html += hidden_field_tag(param, value)
+      end
+      html
+    end
+  end
+
+  ###
+  # @param parameters [ActionController::Parameters]
+  # @return [Hash]
+  def hidden_fields_hash(parameters)
+    parameters.each.reduce({}) do |acc, (param, value)|
+      acc.merge(create_entries(param, value))
+    end
+  end
+
+  ###
+  # @param param [Symbol]
+  # @param value [ActionController::Parameters, Array, String, Integer, Boolean]
+  # @return [Hash]
+  def create_entries(param, value, key = param.to_s, acc = {})
+    case value
+    when ActionController::Parameters
+      value.each do |nested_key, nested_value|
+        create_entries(nested_key, nested_value, key + "[#{nested_key}]", acc)
+      end
+    when Array
+      acc[key + '[]'] = value
+    else
+      acc[key] = value
+    end
+
+    acc
+  end
+end

--- a/app/views/catalog/_results_pagination.html.erb
+++ b/app/views/catalog/_results_pagination.html.erb
@@ -1,12 +1,41 @@
 <% show_json_link ||= false %>
 <% if show_pagination? and @response.total_pages > 1 %>
- <div class="row record-padding">
-  <div class="col-md-12">
-    <div class="pagination">
-      <%= paginate @response, :outer_window => 2, :theme => 'blacklight' %>
-    </div>
-    <%= json_result_link if show_json_link %>
+ <div class="row">
+  <div class="col-md-10">
+    <%= paginate @response, window: 1, outer_window: 2, theme: 'blacklight' %>
   </div>
+  <div class="col-md-2">
+    <div class="pagination jump-to-page">
+      <%= form_tag(search_catalog_path, method: :get, class: 'form-inline') do %>
+        <%= params_as_hidden_fields(params.except(:controller, :action, :page, :commit)) %>
+        <div class="row no-gutters">
+          <div class="form-group">
+            <label for="jump-to-page" class="sr-only">Jump to Page</label>
+            <%=
+              number_field_tag(
+                :page,
+                params[:page],
+                min: 1,
+                max: @response.total_pages,
+                id: 'jump-to-page',
+                class: 'form-control number-to-text jump-to-page',
+                aria: { describedby: 'jump-to-page-desc' }
+              )
+            %>
+            <%= submit_tag 'go', class: 'btn btn-primary' %>
+          </div>
+          <div class="col">
+            <small id="jump-to-page-desc">Jump to Page</small>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+  <% if show_json_link %>
+    <div class="col-md-1">
+      <%= json_result_link %>
+    </div>
+  <% end %>
  </div>
 <% else %>
   <%= json_result_link if show_json_link %>

--- a/spec/helpers/params_helper_spec.rb
+++ b/spec/helpers/params_helper_spec.rb
@@ -1,0 +1,90 @@
+require 'rails_helper'
+
+describe ParamsHelper do
+  let(:context) do
+    Class.new { include ParamsHelper }.new
+  end
+  subject { context.hidden_fields_hash(parameters) }
+
+  describe '#hidden_fields_hash' do
+    context 'with nested parameters' do
+      let(:parameters) do
+        ActionController::Parameters.new(
+          f: ActionController::Parameters.new(
+            collection_name: ['Bethel University', 'Northfield Public Library']
+          )
+        )
+      end
+
+      it 'generates the expected hash' do
+        expect(subject).to eq(
+          'f[collection_name][]' => ['Bethel University', 'Northfield Public Library']
+        )
+      end
+    end
+
+    context 'with flat parameters' do
+      let(:parameters) do
+        ActionController::Parameters.new(
+          foo: 'bar',
+          baz: 'qux'
+        )
+      end
+
+      it 'generates the expected hash' do
+        expect(subject).to eq(
+          'foo' => 'bar',
+          'baz' => 'qux'
+        )
+      end
+    end
+
+    context 'with a mix of flat and nested parameters' do
+      let(:parameters) do
+        ActionController::Parameters.new(
+          f: ActionController::Parameters.new(
+            collection_name: ['Bethel University', 'Northfield Public Library']
+          ),
+          q: ActionController::Parameters.new(
+            r: ActionController::Parameters.new(
+              s: ['t', 'u', 'v']
+            ),
+            w: 'x'
+          ),
+          widgets: ['Widget1', 'Widget2'],
+          limit: 20
+        )
+      end
+
+      it 'generates the expected hash' do
+        expect(subject).to eq(
+          'f[collection_name][]' => ['Bethel University', 'Northfield Public Library'],
+          'q[r][s][]' => ['t', 'u', 'v'],
+          'q[w]' => 'x',
+          'widgets[]' => ['Widget1', 'Widget2'],
+          'limit' => 20
+        )
+      end
+    end
+
+    context 'with a mix of nested depths' do
+      let(:parameters) do
+        ActionController::Parameters.new(
+          q: ActionController::Parameters.new(
+            r: ActionController::Parameters.new(
+              s: ['t', 'u', 'v']
+            ),
+            w: 'x'
+          )
+        )
+      end
+
+      it 'generates the expected hash' do
+        expect(subject).to eq(
+          'q[r][s][]' => ['t', 'u', 'v'],
+          'q[w]' => 'x'
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
This provides a new input alongside the pagination links that allows you to jump to a specific page in the results.

<img width="1131" alt="Screenshot 2023-12-30 at 9 19 35 PM" src="https://github.com/Minitex/mdl_search/assets/815279/2d9b3614-5677-4df6-b74e-ed0b141b5445">
