### PR TITLE
Alleviate resource contention in archive generation

### DIFF
--- a/app/workers/archive_upload_worker.rb
+++ b/app/workers/archive_upload_worker.rb
@@ -1,5 +1,6 @@
 class ArchiveUploadWorker
   include Sidekiq::Worker
+  sidekiq_options queue: :archive_generation
 
   # @param archive_download_request_id [Integer] ID of the ArchiveDownloadRequest
   # @param archive_path [String] file system path of the archive to be uploaded

--- a/app/workers/download_media_worker.rb
+++ b/app/workers/download_media_worker.rb
@@ -1,5 +1,6 @@
 class DownloadMediaWorker
   include Sidekiq::Worker
+  sidekiq_options queue: :archive_generation
 
   # @param archive_download_request_id [Integer] ID of the ArchiveDownloadRequest
   def perform(archive_download_request_id)

--- a/lib/mdl/archive_generator.rb
+++ b/lib/mdl/archive_generator.rb
@@ -91,6 +91,7 @@ module MDL
             filename = File.join(work_dir, "#{basename}.#{ext}")
             response = internet.get(url)
             response.save(filename, 'wb') if response.success?
+            response.finish
           end
         end
 

--- a/start_sidekiq.sh
+++ b/start_sidekiq.sh
@@ -6,6 +6,6 @@
 
 # source env vars
 
-queue="${1:-default -q critical,2}"
+queue="${1:-default -q critical,2 -q archive_generation,1}"
 environment=${RAILS_ENV:-development}
 bundle exec sidekiq -e $environment -q $queue


### PR DESCRIPTION
When we download images for archive generation, we need to release HTTP connections back to the pool (Async ecosystem), which we can do by calling `#finish` on the response. Addionally, this introduces a dedicated Sidekiq queue for archive generation, so we leave the default queue open for the typical indexing responsibilities.