### PR TITLE
Fix 500 error on "missing" facet searches

### DIFF
--- a/app/overrides/blacklight_advanced_search/render_constraints_override_override.rb
+++ b/app/overrides/blacklight_advanced_search/render_constraints_override_override.rb
@@ -25,7 +25,13 @@ module BlacklightAdvancedSearch
           #   f[contributing_organization_ssi][]=somevalue
           # This causes the values to be arrays of Hashes instead of strings
           # so this normalizes them in that situation.
+          #
+          # One exception is the hash { missing: true }, which Blacklight
+          # defines as Blacklight::SearchState::FilterField::MISSING. This
+          # is passed through as is due to its special semantic meaning to
+          # the Blacklight library.
           values = field.values.flat_map do |v|
+            next v if v == Blacklight::SearchState::FilterField::MISSING
             v.respond_to?(:values) ? v.values : v
           end
           render_filter_element(field.key, values, search_state)

--- a/spec/requests/catalog_missing_facet_spec.rb
+++ b/spec/requests/catalog_missing_facet_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+#
+# Blacklight uses Lucene's query semantics around searching
+# for records that don't have a value for a specific field.
+# This test verifies that it works, since we have some logic
+# in RenderConstraintsOverrideOverride that makes some
+# adjustments to the filter constraints rendering.
+#
+describe 'handling the "missing" facet' do
+  it 'renders without erroring' do
+    get('/?q=&range[-dat_ssim][]=[*+TO+*]&search_field=all_fields')
+    expect(response).to have_http_status(:ok)
+  end
+end


### PR DESCRIPTION
When Blacklight renders its facet panels on a search results page, it shows counts of records grouped by facet value. When it encounters a group that has no value for that facet field, it shows a count of "[Missing]" records. Like all facet values, this is a link that further filters the result set. However, this "missing" concept has special representation and handling in the Blacklight library, and we have some code in the app that was dismantling the data structure Blacklight uses to represent a facet field value of "Missing". This fixes the problem so that these facets now work correctly.

<img width="519" alt="Screenshot 2024-08-03 at 9 13 44 PM" src="https://github.com/user-attachments/assets/add67ffc-a623-45b8-ba06-a5735e1fff76">

Clicking this link results in a query string such as

```
q=&range[-dat_ssim][]=[*+TO+*]
```

which gets parsed into a Blacklight FacetField instance for the `dat_ssim` field with sentinel value, `{ missing: true }`. We had fixed an issue previously where requests (from bots, IIRC) were hitting the site using a query string like

```
f[contributing_organization_ssi][0]=somevalue
```

when we were expecting a format like this

```
f[contributing_organization_ssi][]=somevalue
```

and the way it was handled ended up breaking this "[Missing]" facet feature. With this change, the issue should be resolved