### PR TITLE
Stop storing and querying for searches

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -2,6 +2,7 @@
 class CatalogController < ApplicationController
   before_action :permit_search_parameters, only: [:index, :range_limit, :oai]
   before_action :manage_pagination, only: :index
+
   ##
   # Determine whether to render the bookmarks control
   def render_bookmarks_control?
@@ -12,6 +13,18 @@ class CatalogController < ApplicationController
   # Determine whether to render the saved searches link
   def render_saved_searches?
     false
+  end
+
+  ##
+  # Prevents inserts to Blacklight's searches table
+  def start_new_search_session?
+    false
+  end
+
+  ##
+  # Override of Blacklight::SearchContext to prevent queries to
+  # Blacklight's searches table
+  def current_search_session
   end
 
   include Blacklight::Catalog


### PR DESCRIPTION
Blacklight stores all searches by default, and since we don't currently have a use for them, let's stop doing that.