### PR TITLE
Align UV config with v4 extension names

### DIFF
--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -138,9 +138,14 @@
               manifestDisplayOrder: "Contributing Organization,Title,Creator,Contributor,Description,Date of Creation,Dimensions,Minnesota Reflections Topic,Item Type,Item Physical Format,Formal Subject Headings,Locally Assigned Subject Headings,Minnesota City or Township,Minnesota County,State or Province,Country,GeoNames URI,Language,Local Identifier,Fiscal Sponsor,Rights Management,Contact Information"
             }
           },
-          seadragonCenterPanel: {
+          openSeadragonCenterPanel: {
             options: {
               autoHideControls: false,
+              requiredStatementEnabled: false
+            }
+          },
+          mediaelementCenterPanel: {
+            options: {
               requiredStatementEnabled: false
             }
           },


### PR DESCRIPTION
UV is using a new extension for A/V items, so we need to add configuration for that extension that disables the attribution modal by default. Additionally, they changed the configuration module name for the Open Seadragon center panel, so we have to accommodate that as well.