### PR TITLE
Add preventative measures to keep searches table from growing

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -17,18 +17,6 @@ class CatalogController < ApplicationController
     false
   end
 
-  ##
-  # Prevents inserts to Blacklight's searches table
-  def start_new_search_session?
-    false
-  end
-
-  ##
-  # Override of Blacklight::SearchContext to prevent queries to
-  # Blacklight's searches table
-  def current_search_session
-  end
-
   include Blacklight::Catalog
   include BlacklightOaiProvider::Controller
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -152,6 +152,10 @@ class CatalogController < ApplicationController
   end
 
   configure_blacklight do |config|
+    # limit the number of search IDs stored in user's session
+    config.search_history_window = 10
+    # don't store searches for bots
+    config.crawler_detector = CrawlerDetector
     config.add_results_document_tool(:bookmark, partial: 'bookmark_control', if: :render_bookmarks_control?)
 
     config.add_results_collection_tool(:sort_widget)

--- a/app/controllers/crawler_detector.rb
+++ b/app/controllers/crawler_detector.rb
@@ -1,0 +1,8 @@
+class CrawlerDetector
+  BOT_USER_AGENT = /bot|Bot/
+  private_constant :BOT_USER_AGENT
+
+  def self.call(req)
+    req.env['HTTP_USER_AGENT'] =~ BOT_USER_AGENT
+  end
+end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -21,7 +21,7 @@
 
 # Prevent search sessions from bloating our DB
 every 1.day, at: '12:15am' do
-  rake "blacklight_maintenance:truncate_searches"
+  rake 'blacklight:delete_old_searches[1]'
 end
 
 # Pick up new CDM records daily - Index All Items (from all collections)

--- a/spec/requests/search_spec.rb
+++ b/spec/requests/search_spec.rb
@@ -92,4 +92,23 @@ describe 'search' do
       TITLE
     end
   end
+
+  context 'for human visitors' do
+    it 'stores searches' do
+      expect do
+        get '/catalog?search_field=county&q=Hennepin'
+      end.to change(Search, :count).by(1)
+    end
+  end
+
+  context 'for bots' do
+    it 'does not store searches' do
+      headers = {
+        'User-Agent' => 'Mozilla/5.0 (compatible; DataForSeoBot/1.0; +https://dataforseo.com/dataforseo-bot)'
+      }
+      expect do
+        get('/catalog?search_field=county&q=Hennepin', headers:)
+      end.to_not change(Search, :count)
+    end
+  end
 end


### PR DESCRIPTION
Revert "Stop storing and querying for searches" (22e827e2fac1a226bf114fca2ebe099cd0a58d2f)

As it happens, Blacklight depends on stored searches in order to
implement its item-based pagination strategy when viewing an item
surfaced on an SRP.

We have a cron job that runs once daily to truncate the searches table.
This has apparently stopped working at some point, because our searches
table had recently grown to several Gb in size. This updates the crontab
to use the Blacklight-provided rake task instead, with the hope that it
works better than ours. It's unclear why our task would not be
successful, since it's just a simple `truncate searches` command, but
we'll try this and see how it goes.

Additionally, this adds some very naive bot checking based on user agent
that Blacklight uses to determine whether or not to save a search.
