### PR TITLE
Tweak styles for new UV player

### DIFF
--- a/app/assets/stylesheets/mdl.scss
+++ b/app/assets/stylesheets/mdl.scss
@@ -1494,6 +1494,11 @@ a.view-text:hover {
 	padding: 3px;
 }
 
+// override UV style; fighting the specificity battle
+.uv .leftPanel .main .views .thumbsView .thumbs .thumb.selected .wrap {
+	border: 2px solid yellow;
+}
+
 .uv {
 	input {
 		color: rgb(0, 0, 0);
@@ -1501,6 +1506,16 @@ a.view-text:hover {
 
 	.leftPanel .views .thumbsView .thumbs .thumb .wrap.video {
 		background-image: none !important;
+	}
+
+	.thumb {
+		.label {
+			color: white;
+		}
+	}
+
+	.title {
+		color: white;
 	}
 }
 


### PR DESCRIPTION
We need to improve the contrast of a few things in the left content panel. White text on dark background, yellow highlight around selected page.

<img width="1058" alt="Screenshot 2024-09-04 at 8 42 12 PM" src="https://github.com/user-attachments/assets/ca3b9d76-8318-4b83-ba0c-20921c2ef8fd">
