### PR TITLE
Fix duplicated Contributor facet

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -339,6 +339,7 @@ class CatalogController < ApplicationController
       field.index = true
       field.item_presenter = FacetItemPresenter
       field.item_component = FacetItemComponent
+      field.component = Blacklight::FacetFieldListComponent
     end
 
     ###


### PR DESCRIPTION
When searching by contributor from the Advanced Search page, the sidebar facet panel for the Contributor facet is presenting duplicate values. This fixes it by specifying the component to use (for rendering) in the field configuration.