### PR TITLE
Filter IIIF manifest to downloadable assets

### DIFF
--- a/lib/mdl/download_asset.rb
+++ b/lib/mdl/download_asset.rb
@@ -10,8 +10,10 @@ module MDL
       # @return [Array<MDL::DownloadAsset>]
       def assets_from_manifest_v2(manifest)
         Array(manifest.dig('sequences', 0, 'canvases'))
-          .map do |canvas|
+          .filter_map do |canvas|
             url = canvas.dig('images', 0, 'resource', '@id')
+            next if url.nil?
+
             label = canvas['label']
             new(
               label: label,


### PR DESCRIPTION
Some canvases don't have images. In that case, there is no need to provide a download asset for it.