### PR TITLE
Fix oclc image urls

### DIFF
--- a/lib/mdl/iiif_manifest_formatter.rb
+++ b/lib/mdl/iiif_manifest_formatter.rb
@@ -19,7 +19,9 @@ module MDL
 
         url = "https://cdm16022.contentdm.oclc.org/iiif/2/#{collection}:#{id}/manifest.json"
         res = Net::HTTP.get_response(URI(url))
-        self.format(doc, retries - 1) if res.code != '200' && retries.positive?
+        retries -= 1
+        self.format(doc, retries) if res.code != '200' && retries.positive?
+        return unless res.code == '200'
 
         parsed_response = JSON.parse(res.body)
         parsed_response['service'] = {
@@ -45,7 +47,7 @@ module MDL
           # With this, UV will support "two-up" (side-by-side) pages
           # in the viewer. Only makes sense visually if there are
           # at least three canvases (pages).
-          manifest['sequences'][0]['viewingHint'] = 'paged'
+          sequence['viewingHint'] = 'paged'
         end
       end
 

--- a/spec/lib/mdl/iiif_manifest_formatter_spec.rb
+++ b/spec/lib/mdl/iiif_manifest_formatter_spec.rb
@@ -119,6 +119,25 @@ module MDL
           expect(described_class.format(doc)).to be_nil
         end
       end
+
+      context 'when the manifest is not found' do
+        let(:body) do
+          <<~JSON
+            {
+              "title": "Not Found",
+              "status": 404
+            }
+          JSON
+        end
+        let(:mock_response) do
+          double('response', code: '404', body:)
+        end
+
+        it 'returns nil after three tries' do
+          expect(described_class.format(doc)).to be(nil)
+          expect(Net::HTTP).to have_received(:get_response).thrice
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
**Retry failed downloads for image OCR in IIIF Search processing**

I suspect CDM may just be getting overwhelmed with requests and returning
a non-200 status code in some cases. To attempt to succeed under these
conditions, I'm adding a retry for the image download.

**Gracefully handle 404 in IIIFManifestFormatter**
    
We've been failing to halt processing when we get a 404 calling CDM
for a IIIF manifest. That has resulted in runtime errors because the
response body for an unsuccessful request doesn't match our expectations

This fixes the issue by halting processing when we don't get a 200 on the
manifest response.