### PR TITLE
Fix issue with JSON parsing of complex document trascription

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -373,7 +373,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    json (2.6.2)
+    json (2.9.1)
     jwt (2.4.1)
     kaltura-client (18.10.0)
       rest-client

--- a/config/initializers/json.rb
+++ b/config/initializers/json.rb
@@ -1,2 +1,0 @@
-require 'json/pure'
-JSON.parser = JSON::Pure::Parser


### PR DESCRIPTION
What was manifesting as an encoding issue seems to be fixed by updating the json gem. Ruby was reporting the string as valid UTF-8, but the older version of the gem was claiming a portion of the string was ASCII-8bit.