### PR TITLE
Add GalleryDocumentComponent to serve gallery index view

### DIFF
--- a/app/components/facet_item_component.rb
+++ b/app/components/facet_item_component.rb
@@ -50,22 +50,14 @@ class FacetItemComponent < Blacklight::FacetItemComponent
 
   def label_class(label)
     case label
-    when 'Still Image'
-      'icon-image'
-    when 'Moving Image'
-      'icon-video'
-    when 'Text'
-      'icon-text'
-    when 'Sound Recording Nonmusical'
-      'icon-sound'
-    when 'Three Dimensional Object'
-      'icon-object'
-    when 'Notated Music'
-      'icon-sheet-music'
-    when 'Mixed Material'
-      'icon-archive'
-    when 'Cartographic'
-      'icon-map'
+    when 'Still Image' then 'icon-image'
+    when 'Moving Image' then 'icon-video'
+    when 'Text' then 'icon-text'
+    when 'Sound Recording Nonmusical' then 'icon-sound'
+    when 'Three Dimensional Object' then 'icon-object'
+    when 'Notated Music' then 'icon-sheet-music'
+    when 'Mixed Material' then 'icon-archive'
+    when 'Cartographic' then 'icon-map'
     end
   end
 end

--- a/app/components/gallery_document_component.html.erb
+++ b/app/components/gallery_document_component.html.erb
@@ -1,0 +1,11 @@
+<div class="panel panel-default gallery-result document">
+  <%= document_actions %>
+  <div class="panel-body">
+    <div class="image-wrapper">
+      <%= thumbnail_link %>
+    </div>
+    <div class="title">
+      <%= title_link %>
+    </div>
+  </div>
+</div>

--- a/app/components/gallery_document_component.rb
+++ b/app/components/gallery_document_component.rb
@@ -1,0 +1,24 @@
+class GalleryDocumentComponent < Blacklight::Gallery::DocumentComponent
+  def thumbnail_link
+    helpers.document_show_link(
+      document: @document,
+      label: helpers.thumbnail_tag(@document),
+      counter: @counter
+    )
+  end
+
+  def title_link
+    helpers.link_to_document(
+      @document,
+      helpers.document_show_link_field(@document),
+      counter: @counter
+    )
+  end
+
+  def document_actions
+    helpers.render_index_doc_actions(
+      @document,
+      wrapping_class: "index-document-functions col-sm-3 col-lg-2"
+    )
+  end
+end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -209,7 +209,8 @@ class CatalogController < ApplicationController
       default: false,
       partials: [:index],
       icon_class: 'glyphicon-th',
-      classes: []
+      classes: [],
+      document_component: GalleryDocumentComponent
     )
 
     ###


### PR DESCRIPTION
Something changed in how blacklight-gallery renders its views between v4.0.1 and v4.6.1. They seem to depend on a ViewComponents implementation, which is inline with the overall direction of the Blacklight libraries. We have been using the legacy view partial overrides to customize the gallery appearance, and that is no longer a viable solution. This introduces a GalleryDocumentComponent class that will accommodate the expected rendering approach.

The document structure has also changed as a result of the upgrade, so some of the CSS is no longer working. This doesn't address that issue.