### PR TITLE
Fix UnsafeRedirectError

### DIFF
--- a/app/controllers/thumbnails_controller.rb
+++ b/app/controllers/thumbnails_controller.rb
@@ -3,6 +3,6 @@ class ThumbnailsController < ApplicationController
     collection, id = params[:id].split(':')
     thumbnail = MDL::Thumbnail.new(collection:, id:, type: params[:type])
 
-    redirect_to thumbnail.thumbnail_url
+    redirect_to thumbnail.thumbnail_url, allow_other_host: true
   end
 end

--- a/spec/controllers/thumbnails_controller_spec.rb
+++ b/spec/controllers/thumbnails_controller_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+describe ThumbnailsController do
+  describe 'GET to #show' do
+    let(:params) do
+      { id: 'asdf:123', type: }
+    end
+
+    context 'when type is "Sound Recording Nonmusical"' do
+      let(:type) { 'Sound Recording Nonmusical' }
+
+      it 'redirects to the default audio URL' do
+        get(:show, params:)
+
+        expect(response).to redirect_to('/images/audio-3.png')
+      end
+    end
+
+    context 'when type is "Moving Image"' do
+      let(:type) { 'Moving Image' }
+
+      it 'redirects to the default video URL' do
+        get(:show, params:)
+
+        expect(response).to redirect_to('/images/video-1.png')
+      end
+    end
+
+    context 'when type is absent' do
+      let(:type) { '' }
+
+      it 'redirects to ContentDM' do
+        get(:show, params:)
+
+        expect(response).to redirect_to(
+          'https://cdm16022.contentdm.oclc.org/utils/getthumbnail/collection/asdf/id/123'
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Rails started raising this error on open redirects, where the Location header points to a different domain than the request's Host. This explicitly allows for that on the ThumbnailsController, which needs to redirect to ContentDM most of the time.