### PR TITLE
Silence Blacklight's deprecation warnings in deployed envs

### DIFF
--- a/config/initializers/blacklight.rb
+++ b/config/initializers/blacklight.rb
@@ -1,0 +1,6 @@
+# Deprecation is a dependency of Blacklight, and the Blacklight libraries use it
+# to log deprecations. We want to silence them in deployed environments so they
+# don't flood the logs.
+if Rails.env.production?
+  Deprecation.default_deprecation_behavior = :silence
+end


### PR DESCRIPTION
Blacklight uses a gem called `deprecation` that they use to log their deprecation warnings. The Rails config for ActiveSupport deprecations does not affect this gem, so we need to configure it separately if we want to customize its behavior. Here, we're silencing deprecations when Rails.env is production.